### PR TITLE
Introduce changes recommended in the kernel mailing list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 VERSION         := 0.08
 DKMS_ROOT_PATH  := /usr/src/msi_ec-$(VERSION)
 
+ccflags-y := -std=gnu11 -Wno-declaration-after-statement
+
 obj-m += msi-ec.o
 
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -44,6 +44,7 @@
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
 #include <linux/string.h>
+#include <linux/slab.h>
 
 static const char *const SM_ECO_NAME       = "eco";
 static const char *const SM_COMFORT_NAME   = "comfort";
@@ -1388,6 +1389,8 @@ static int msi_platform_probe(struct platform_device *pdev)
 	// supported root attributes
 	struct attribute **msi_root_attrs =
 		kcalloc(attributes_count, sizeof(struct attribute *), GFP_KERNEL);
+	if (!msi_root_attrs)
+		return -ENOMEM;
 
 	// copy supported attributes only
 	for (int i = 0, j = 0; i < attributes_count; i++) {
@@ -1404,7 +1407,7 @@ static int msi_platform_probe(struct platform_device *pdev)
 static int msi_platform_remove(struct platform_device *pdev)
 {
 	sysfs_remove_groups(&pdev->dev.kobj, msi_platform_groups);
-	kvfree(msi_root_group.attrs);
+	kfree(msi_root_group.attrs);
 	return 0;
 }
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -606,7 +606,7 @@ static ssize_t charge_control_threshold_show(u8 offset, struct device *device,
 	if (result < 0)
 		return result;
 
-	return sprintf(buf, "%i\n", rdata - offset);
+	return sysfs_emit(buf, "%i\n", rdata - offset);
 }
 
 static ssize_t charge_control_threshold_store(u8 offset, struct device *dev,
@@ -712,9 +712,9 @@ static ssize_t webcam_common_show(u8 address,
 		return result;
 
 	if (bit_value) {
-		return sprintf(buf, "%s\n", str_on_1);
+		return sysfs_emit(buf, "%s\n", str_on_1);
 	} else {
-		return sprintf(buf, "%s\n", str_on_0);
+		return sysfs_emit(buf, "%s\n", str_on_0);
 	}
 }
 
@@ -783,9 +783,9 @@ static ssize_t fn_key_show(struct device *device, struct device_attribute *attr,
 	result = ec_check_bit(conf.fn_win_swap.address, conf.fn_win_swap.bit, &bit_value);
 
 	if (bit_value) {
-		return sprintf(buf, "%s\n", "right");
+		return sysfs_emit(buf, "%s\n", "right");
 	} else {
-		return sprintf(buf, "%s\n", "left");
+		return sysfs_emit(buf, "%s\n", "left");
 	}
 }
 
@@ -815,9 +815,9 @@ static ssize_t win_key_show(struct device *device,
 	result = ec_check_bit(conf.fn_win_swap.address, conf.fn_win_swap.bit, &bit_value);
 
 	if (bit_value) {
-		return sprintf(buf, "%s\n", "left");
+		return sysfs_emit(buf, "%s\n", "left");
 	} else {
-		return sprintf(buf, "%s\n", "right");
+		return sysfs_emit(buf, "%s\n", "right");
 	}
 }
 
@@ -849,13 +849,13 @@ static ssize_t battery_mode_show(struct device *device,
 		return result;
 
 	if (rdata == conf.charge_control.range_max) {
-		return sprintf(buf, "%s\n", "max");
+		return sysfs_emit(buf, "%s\n", "max");
 	} else if (rdata == conf.charge_control.offset_end + 80) { // up to 80%
-		return sprintf(buf, "%s\n", "medium");
+		return sysfs_emit(buf, "%s\n", "medium");
 	} else if (rdata == conf.charge_control.offset_end + 60) { // up to 60%
-		return sprintf(buf, "%s\n", "min");
+		return sysfs_emit(buf, "%s\n", "min");
 	} else {
-		return sprintf(buf, "%s (%i)\n", "unknown", rdata);
+		return sysfs_emit(buf, "%s (%i)\n", "unknown", rdata);
 	}
 }
 
@@ -892,9 +892,9 @@ static ssize_t cooler_boost_show(struct device *device,
 	result = ec_check_bit(conf.cooler_boost.address, conf.cooler_boost.bit, &bit_value);
 
 	if (bit_value) {
-		return sprintf(buf, "%s\n", "on");
+		return sysfs_emit(buf, "%s\n", "on");
 	} else {
-		return sprintf(buf, "%s\n", "off");
+		return sysfs_emit(buf, "%s\n", "off");
 	}
 }
 
@@ -928,7 +928,7 @@ static ssize_t available_shift_modes_show(struct device *device,
 	for (int i = 0; conf.shift_mode.modes[i].name; i++) {
 		// NULL entries have NULL name
 
-		result = sprintf(buf + count, "%s\n", conf.shift_mode.modes[i].name);
+		result = sysfs_emit_at(buf, count, "%s\n", conf.shift_mode.modes[i].name);
 		if (result < 0)
 			return result;
 		count += result;
@@ -949,17 +949,17 @@ static ssize_t shift_mode_show(struct device *device,
 		return result;
 
 	if (rdata == 0x80)
-		return sprintf(buf, "%s\n", "unspecified");
+		return sysfs_emit(buf, "%s\n", "unspecified");
 
 	for (int i = 0; conf.shift_mode.modes[i].name; i++) {
 		// NULL entries have NULL name
 
 		if (rdata == conf.shift_mode.modes[i].value) {
-			return sprintf(buf, "%s\n", conf.shift_mode.modes[i].name);
+			return sysfs_emit(buf, "%s\n", conf.shift_mode.modes[i].name);
 		}
 	}
 
-	return sprintf(buf, "%s (%i)\n", "unknown", rdata);
+	return sysfs_emit(buf, "%s (%i)\n", "unknown", rdata);
 }
 
 static ssize_t shift_mode_store(struct device *dev,
@@ -995,9 +995,9 @@ static ssize_t super_battery_show(struct device *device,
 				  &enabled);
 
 	if (enabled) {
-		return sprintf(buf, "%s\n", "on");
+		return sysfs_emit(buf, "%s\n", "on");
 	} else {
-		return sprintf(buf, "%s\n", "off");
+		return sysfs_emit(buf, "%s\n", "off");
 	}
 }
 
@@ -1031,7 +1031,7 @@ static ssize_t available_fan_modes_show(struct device *device,
 	for (int i = 0; conf.fan_mode.modes[i].name; i++) {
 		// NULL entries have NULL name
 
-		result = sprintf(buf + count, "%s\n", conf.fan_mode.modes[i].name);
+		result = sysfs_emit_at(buf, count, "%s\n", conf.fan_mode.modes[i].name);
 		if (result < 0)
 			return result;
 		count += result;
@@ -1054,11 +1054,11 @@ static ssize_t fan_mode_show(struct device *device,
 		// NULL entries have NULL name
 
 		if (rdata == conf.fan_mode.modes[i].value) {
-			return sprintf(buf, "%s\n", conf.fan_mode.modes[i].name);
+			return sysfs_emit(buf, "%s\n", conf.fan_mode.modes[i].name);
 		}
 	}
 
-	return sprintf(buf, "%s (%i)\n", "unknown", rdata);
+	return sysfs_emit(buf, "%s (%i)\n", "unknown", rdata);
 }
 
 static ssize_t fan_mode_store(struct device *dev, struct device_attribute *attr,
@@ -1092,7 +1092,7 @@ static ssize_t fw_version_show(struct device *device,
 	if (result < 0)
 		return result;
 
-	return sprintf(buf, "%s\n", rdata);
+	return sysfs_emit(buf, "%s\n", rdata);
 }
 
 static ssize_t fw_release_date_show(struct device *device,
@@ -1117,8 +1117,8 @@ static ssize_t fw_release_date_show(struct device *device,
 		return result;
 	sscanf(rtime, "%02d:%02d:%02d", &hour, &minute, &second);
 
-	return sprintf(buf, "%04d/%02d/%02d %02d:%02d:%02d\n", year, month, day,
-		       hour, minute, second);
+	return sysfs_emit(buf, "%04d/%02d/%02d %02d:%02d:%02d\n", year, month, day,
+		          hour, minute, second);
 }
 
 static DEVICE_ATTR_RW(webcam);
@@ -1150,7 +1150,7 @@ static ssize_t cpu_realtime_temperature_show(struct device *device,
 	if (result < 0)
 		return result;
 
-	return sprintf(buf, "%i\n", rdata);
+	return sysfs_emit(buf, "%i\n", rdata);
 }
 
 static ssize_t cpu_realtime_fan_speed_show(struct device *device,
@@ -1168,10 +1168,10 @@ static ssize_t cpu_realtime_fan_speed_show(struct device *device,
 	    rdata > conf.cpu.rt_fan_speed_base_max))
 		return -EINVAL;
 
-	return sprintf(buf, "%i\n",
-		       100 * (rdata - conf.cpu.rt_fan_speed_base_min) /
-			       (conf.cpu.rt_fan_speed_base_max -
-				conf.cpu.rt_fan_speed_base_min));
+	return sysfs_emit(buf, "%i\n",
+		          100 * (rdata - conf.cpu.rt_fan_speed_base_min) /
+				  (conf.cpu.rt_fan_speed_base_max -
+				   conf.cpu.rt_fan_speed_base_min));
 }
 
 static ssize_t cpu_basic_fan_speed_show(struct device *device,
@@ -1189,10 +1189,10 @@ static ssize_t cpu_basic_fan_speed_show(struct device *device,
 	    rdata > conf.cpu.bs_fan_speed_base_max)
 		return -EINVAL;
 
-	return sprintf(buf, "%i\n",
-		       100 * (rdata - conf.cpu.bs_fan_speed_base_min) /
-			       (conf.cpu.bs_fan_speed_base_max -
-				conf.cpu.bs_fan_speed_base_min));
+	return sysfs_emit(buf, "%i\n",
+		          100 * (rdata - conf.cpu.bs_fan_speed_base_min) /
+				  (conf.cpu.bs_fan_speed_base_max -
+				   conf.cpu.bs_fan_speed_base_min));
 }
 
 static ssize_t cpu_basic_fan_speed_store(struct device *dev,
@@ -1272,7 +1272,7 @@ static ssize_t gpu_realtime_temperature_show(struct device *device,
 	if (result < 0)
 		return result;
 
-	return sprintf(buf, "%i\n", rdata);
+	return sysfs_emit(buf, "%i\n", rdata);
 }
 
 static ssize_t gpu_realtime_fan_speed_show(struct device *device,
@@ -1286,7 +1286,7 @@ static ssize_t gpu_realtime_fan_speed_show(struct device *device,
 	if (result < 0)
 		return result;
 
-	return sprintf(buf, "%i\n", rdata);
+	return sysfs_emit(buf, "%i\n", rdata);
 }
 
 static struct device_attribute dev_attr_gpu_realtime_temperature = {

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -31,6 +31,8 @@
  *
  */
 
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
 #include "ec_memory_configuration.h"
 
 #include <acpi/battery.h>
@@ -1563,7 +1565,7 @@ static int __init msi_ec_init(void)
 	if (conf.kbd_bl.bl_state_address != MSI_EC_ADDR_UNKNOWN)
 		led_classdev_register(&msi_platform_device->dev, &msiacpi_led_kbdlight);
 
-	pr_info("msi-ec: module_init\n");
+	pr_info("module_init\n");
 	return 0;
 }
 
@@ -1584,7 +1586,7 @@ static void __exit msi_ec_exit(void)
 	platform_driver_unregister(&msi_platform_driver);
 	platform_device_del(msi_platform_device);
 
-	pr_info("msi-ec: module_exit\n");
+	pr_info("module_exit\n");
 }
 
 MODULE_LICENSE("GPL");

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1324,8 +1324,6 @@ static const struct attribute_group *msi_platform_groups[] = {
 
 static int msi_platform_probe(struct platform_device *pdev)
 {
-	int result;
-
 	// ALL root attributes and their support flags
 	struct attribute_support msi_root_attrs_support[] = {
 		{
@@ -1531,11 +1529,6 @@ static int __init load_configuration(void)
 static int __init msi_ec_init(void)
 {
 	int result;
-
-	if (acpi_disabled) {
-		pr_err("Unable to init because ACPI needs to be enabled first!\n");
-		return -ENODEV;
-	}
 
 	result = load_configuration();
 	if (result < 0)

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -482,11 +482,10 @@ static int strcmp_trim_newline2(const char *s, const char *s_nl)
 	return strcmp(s, s_nl);
 }
 
-static int ec_read_seq(u8 addr, u8 *buf, int len)
+static int ec_read_seq(u8 addr, u8 *buf, u8 len)
 {
 	int result;
-	u8 i;
-	for (i = 0; i < len; i++) {
+	for (u8 i = 0; i < len; i++) {
 		result = ec_read(addr + i, buf + i);
 		if (result < 0)
 			return result;
@@ -678,9 +677,7 @@ ATTRIBUTE_GROUPS(msi_battery);
 
 static int msi_battery_add(struct power_supply *battery)
 {
-	if (device_add_groups(&battery->dev, msi_battery_groups))
-		return -ENODEV;
-	return 0;
+	return device_add_groups(&battery->dev, msi_battery_groups);
 }
 
 static int msi_battery_remove(struct power_supply *battery)
@@ -1401,11 +1398,7 @@ static int msi_platform_probe(struct platform_device *pdev)
 	// save attributes in the group
 	msi_root_group.attrs = msi_root_attrs;
 
-	result = sysfs_create_groups(&pdev->dev.kobj, msi_platform_groups);
-	if (result < 0)
-		return result;
-
-	return 0;
+	return sysfs_create_groups(&pdev->dev.kobj, msi_platform_groups);
 }
 
 static int msi_platform_remove(struct platform_device *pdev)


### PR DESCRIPTION
- use sysfs_emit() instead of sprintf() to prevent buffer overflow
- remove unnecessary ACPI check
- make i and len in ec_read_seq() the same type
- better error handling
- use pr_fmt for convenience