### PR TITLE
Add debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,15 @@ clean:
 load:
 	insmod msi-ec.ko
 
+load-debug:
+	insmod msi-ec.ko debug=1
+
 unload:
 	-rmmod msi-ec
 
 reload: unload load
+
+reload-debug: unload load-debug
 
 install:
 	mkdir -p /lib/modules/$(shell uname -r)/extra

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 VERSION         := 0.08
 DKMS_ROOT_PATH  := /usr/src/msi_ec-$(VERSION)
 
+ccflags-y := -std=gnu11 -Wno-declaration-after-statement
+
 obj-m += msi-ec.o
 
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Also, and until future enhancements, no DMI data is used to identify your laptop
    - For Ubuntu: `build-essential linux-headers-generic`
    - For Fedora: `kernel-devel`
 2. Clone this repository and cd to it
-3. (Linux < 6.2 only) Run `make patch-pre-6.2`
+3. (Linux < 6.2 only) Run `make older-kernel-patch`
 4. Run `make`
 5. Run `make install`
 6. (Optional) To uninstall, run `make uninstall`

--- a/README.md
+++ b/README.md
@@ -179,6 +179,33 @@ Led subsystem allows us to control the leds on the laptop including the keyboard
     - 2: Half
     - 3: Full
 
+### Debug mode
+
+You can use module *parameters* to get direct read-write access to the EC or force-load a configuration
+for a specific firmware.
+
+**Be very careful, since writing into the unknown addresses of the EC memory may be dangerous!**.
+If you did something wrong, please, reset the EC using the reset button on the bottom of your laptop.
+
+#### `debug`, bool
+
+Set this parameter to `true` to enable debug attributes, located at `/sys/devices/platform/msi-ec/debug/`,
+even if your EC is not supported yet.
+Normal attributes will still be accessible if your firmware is supported.
+
+You can use `make load-debug` command to load the module in the debug mode after building it from source.
+
+| name       | permissions | description                                                                                                                                                                    |
+|------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| fw_version | RO          | returns your EC firmware version                                                                                                                                               |
+| ec_dump    | RO          | returns an EC memory dump in the form of a table                                                                                                                               |
+| ec_get     | RW          | receives an EC memory address in the hexadecimal format or write; returns a value stored in the EC memory at this address on read                                              |
+| ec_set     | WO          | receives an address-value pair in the following format: `aa=vv`, where `aa` and `vv` are address and value in the hexadecimal format; then writes the value into the EC memory |
+
+#### `firmware`, string
+
+Set this parameter to a supported EC firmware version to use its configuration and test if it is compatible with your EC.
+**Please verify that the attributes return the correct data before attempting to write into them!**
 
 ## List of tested laptops:
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Led subsystem allows us to control the leds on the laptop including the keyboard
 You can use module *parameters* to get direct read-write access to the EC or force-load a configuration
 for a specific firmware.
 
-**Be very careful, since writing into the unknown addresses of the EC memory may be dangerous!**.
+**Be very careful, since writing into the unknown addresses of the EC memory may be dangerous!**
 If you did something wrong, please, reset the EC using the reset button on the bottom of your laptop.
 
 #### `debug`, bool
@@ -199,7 +199,7 @@ You can use `make load-debug` command to load the module in the debug mode after
 |------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | fw_version | RO          | returns your EC firmware version                                                                                                                                               |
 | ec_dump    | RO          | returns an EC memory dump in the form of a table                                                                                                                               |
-| ec_get     | RW          | receives an EC memory address in the hexadecimal format or write; returns a value stored in the EC memory at this address on read                                              |
+| ec_get     | RW          | receives an EC memory address in the hexadecimal format on write; returns a value stored in the EC memory at this address on read                                              |
 | ec_set     | WO          | receives an address-value pair in the following format: `aa=vv`, where `aa` and `vv` are address and value in the hexadecimal format; then writes the value into the EC memory |
 
 #### `firmware`, string

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -44,6 +44,7 @@
 #include <linux/proc_fs.h>
 #include <linux/seq_file.h>
 #include <linux/string.h>
+#include <linux/slab.h>
 
 static const char *const SM_ECO_NAME       = "eco";
 static const char *const SM_COMFORT_NAME   = "comfort";
@@ -1388,6 +1389,8 @@ static int msi_platform_probe(struct platform_device *pdev)
 	// supported root attributes
 	struct attribute **msi_root_attrs =
 		kcalloc(attributes_count, sizeof(struct attribute *), GFP_KERNEL);
+	if (!msi_root_attrs)
+		return -ENOMEM;
 
 	// copy supported attributes only
 	for (int i = 0, j = 0; i < attributes_count; i++) {
@@ -1404,7 +1407,7 @@ static int msi_platform_probe(struct platform_device *pdev)
 static int msi_platform_remove(struct platform_device *pdev)
 {
 	sysfs_remove_groups(&pdev->dev.kobj, msi_platform_groups);
-	kvfree(msi_root_group.attrs);
+	kfree(msi_root_group.attrs);
 	return 0;
 }
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1007,7 +1007,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF8,
 	&CONF9,
 	&CONF10,
-    &CONF11,
+	&CONF11,
 	NULL
 };
 
@@ -1025,7 +1025,7 @@ MODULE_PARM_DESC(firmware, "Load a configuration for a specified firmware versio
 
 static bool debug = false;
 module_param(debug, bool, 0);
-MODULE_PARM_DESC(debug, "Load driver in debug mode, only export debug attributes");
+MODULE_PARM_DESC(debug, "Load the driver in the debug mode, exporting the debug attributes");
 
 // ============================================================ //
 // Helper functions

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -31,6 +31,8 @@
  *
  */
 
+#define pr_fmt(fmt) KBUILD_MODNAME ": " fmt
+
 #include "ec_memory_configuration.h"
 
 #include <acpi/battery.h>
@@ -1563,7 +1565,7 @@ static int __init msi_ec_init(void)
 	if (conf.kbd_bl.bl_state_address != MSI_EC_ADDR_UNKNOWN)
 		led_classdev_register(&msi_platform_device->dev, &msiacpi_led_kbdlight);
 
-	pr_info("msi-ec: module_init\n");
+	pr_info("module_init\n");
 	return 0;
 }
 
@@ -1584,7 +1586,7 @@ static void __exit msi_ec_exit(void)
 	platform_driver_unregister(&msi_platform_driver);
 	platform_device_del(msi_platform_device);
 
-	pr_info("msi-ec: module_exit\n");
+	pr_info("module_exit\n");
 }
 
 MODULE_LICENSE("GPL");

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1324,8 +1324,6 @@ static const struct attribute_group *msi_platform_groups[] = {
 
 static int msi_platform_probe(struct platform_device *pdev)
 {
-	int result;
-
 	// ALL root attributes and their support flags
 	struct attribute_support msi_root_attrs_support[] = {
 		{
@@ -1531,11 +1529,6 @@ static int __init load_configuration(void)
 static int __init msi_ec_init(void)
 {
 	int result;
-
-	if (acpi_disabled) {
-		pr_err("Unable to init because ACPI needs to be enabled first!\n");
-		return -ENODEV;
-	}
 
 	result = load_configuration();
 	if (result < 0)

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1365,12 +1365,12 @@ static ssize_t ec_dump_show(struct device *device,
 static DEVICE_ATTR_RO(ec_dump);
 
 static struct attribute *msi_debug_attrs[] = {
+	&dev_attr_fw_version.attr,
 	&dev_attr_ec_dump.attr,
 	NULL
 };
 
 static const struct attribute_group msi_debug_group = {
-	.name = "debug",
 	.attrs = msi_debug_attrs,
 };
 


### PR DESCRIPTION
Debug mode lets the user load the module on unsupported hardware to collect information required to add a new configuration.

Currently has EC dump implemented. This way we won't have to use isw which requires an additional acpi_ec module on some distros.

(!) Depends on #17, first 4 commits are from that PR, so you can review it first.