### PR TITLE
Add MSI Katana GF66 11UC support

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -841,6 +841,84 @@ static struct msi_ec_conf CONF9 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_10[] __initconst = {
+	"1582EMS1.107", // GF66 11UC
+	NULL
+};
+
+static struct msi_ec_conf CONF10 __initdata = {
+	.allowed_fw = ALLOWED_FW_10,
+	.charge_control = {
+		.address      = 0xd7,
+		.offset_start = 0x8a,
+		.offset_end   = 0x80,
+		.range_min    = 0x8a,
+		.range_max    = 0xe4,
+	},
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = MSI_EC_ADDR_UNSUPP,
+		.bit     = 4,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 },
+			{ SM_COMFORT_NAME, 0xc1 },
+			{ SM_SPORT_NAME,   0xc0 },
+			{ SM_TURBO_NAME,   0xc4 },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xe5,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address       = 0x68,
+		.rt_fan_speed_address  = 0x71, // ?
+		.rt_fan_speed_base_min = 0x19,
+		.rt_fan_speed_base_max = 0x37,
+		.bs_fan_speed_address  = MSI_EC_ADDR_UNKNOWN, // ?
+		.bs_fan_speed_base_min = 0x00,
+		.bs_fan_speed_base_max = 0x0f,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0x89,
+	},
+	.leds = {
+		.micmute_led_address = 0x2c,
+		.mute_led_address    = 0x2d,
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = 0x2c,
+		.bl_modes         = { 0x00, 0x08 },
+		.max_mode         = 1,
+		.bl_state_address = 0xd3,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -852,6 +930,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF7,
 	&CONF8,
 	&CONF9,
+	&CONF10,
 	NULL
 };
 


### PR DESCRIPTION
**How I tested**: by setting values at the mentioned paths and observing the behavior and also observing `ec` realtime values (`sudo watch -n 0.1 hexdump -C /dev/ec`)

## Tested & Working

- WebCam:`/sys/devices/platform/msi-ec/webcam`
- WebCam Block:`/sys/devices/platform/msi-ec/webcam_block`
- Battery mode: `/sys/devices/platform/msi-ec/battery_mode`
- Cooler booster: `/sys/devices/platform/msi-ec/cooler_boost`
- CPU Realtime temperature: `/sys/devices/platform/msi-ec/cpu/realtime_temperature`
- GPU Realtime temperature: `/sys/devices/platform/msi-ec/gpu/realtime_temperature`
  - Also verified from NVIDIA application.
  - Value was non zero when I was utilizing GPU
- GPU Realtime Fan Speed:  `/sys/devices/platform/msi-ec/gpu/realtime_fan_speed`
  - Value was non zero when I was utilizing GPU
- Fan Mode: `/sys/devices/platform/msi-ec/fan_mode`
    - auto, silent and advanced
- Firmware version: `/sys/devices/platform/msi-ec/fw_version`
- Firmware version release date: `/sys/devices/platform/msi-ec/fw_release_date`
- keyboard backlight:`/sys/class/leds/msiacpi::kbd_backlight/brightness`
- Mic Mute LED: `/sys/class/leds/platform::micmute/brightness`
- Mute LED: `/sys/class/leds/platform::mute/brightness`
- Charge Threshold: `/sys/class/power_supply/BAT1/charge_control_end_threshold`
- Shift Mode: `/sys/devices/platform/msi-ec/shift_mode`
  - I was able to set values without error and the value is set to `sport` on startup (In BIOS, if user scenario is set to `Performance Mode`)
  - and value is set to `comfort` on startup (In BIOS, if user scenario is set to `Balanced Mode`)
  - Verified on Windows
  - 
    In Windows | In MSI-EC Driver | Value
    | ------ | ------ | ------ |
    | Turbo | Turbo | C4 |
    High | Sport | C0
    Medium | Comfort | C1
    Low | Eco | C2


## Not sure if it's working right

- CPU Realtime Fan Speed: `/sys/devices/platform/msi-ec/cpu/realtime_fan_speed`
  - The address might be correct and the value definitely correlates to speed of the fan but also one time it got stuck at `0x55` even the speed of the fan speed got slow, so not sure what's the about this configuration 
  - But the value has gone up to `0x55` and `rt_fan_speed_base_max` is set to `0x37`, so if it goes beyond the `0x37` then it starts showing `Invalid argument`
  - I believe the `rt_fan_speed_base_min` should be `0x00` -> `0` and `rt_fan_speed_base_max` be `0x64` -> `100` 

## Not supported

- function windows button swap: `/sys/devices/platform/msi-ec/fn_key` & `/sys/devices/platform/msi-ec/win_key`
  - I was not able to see this feature in either MSI control panel in Windows and MSI official docs for the particular laptop model and also tried with the values set in existing conf's just to sure but it did not worked. 
 
  
## Sample EC Dump

```
00000000  00 80 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  0a 05 00 00 00 04 0b 0b  |................|
00000030  03 09 00 0d 01 00 50 81  d2 11 88 2c c8 01 e0 00  |......P....,....|
00000040  00 00 62 00 e6 0e 00 00  86 0e ca 30 01 0c 00 00  |..b........0....|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  5e 00 37 40 49 4c 52 58  |........^.7@ILRX|
00000070  64 55 26 2b 30 36 3c 46  55 64 08 03 03 03 03 03  |dU&+06<FUd......|
00000080  00 00 37 3d 43 49 4f 54  63 00 00 2b 30 36 3c 46  |..7=CIOTc..+06<F|
00000090  55 64 08 03 03 03 03 02  02 0f 7d 02 0a 78 5a 00  |Ud........}..xZ.|
000000a0  31 35 38 32 45 4d 53 31  2e 31 30 37 30 33 31 30  |1582EMS1.1070310|
000000b0  32 30 32 33 31 35 3a 31  30 3a 31 39 00 00 00 28  |202315:10:19...(|
000000c0  00 00 06 22 00 00 00 00  00 5e 00 b3 00 00 00 00  |...".....^......|
000000d0  00 00 c1 83 0d 0f 05 e4  00 01 00 00 00 00 00 00  |................|
000000e0  e2 00 00 e8 0e 0f 00 40  00 00 00 00 00 c0 00 00  |.......@........|
000000f0  00 00 70 00 00 64 00 00  64 00 00 00 00 00 00 00  |..p..d..d.......|
00000100
```