### PR TITLE
msi-ec : add support gp66-11ug

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -995,6 +995,88 @@ static struct msi_ec_conf CONF11 __initdata = {
     },
 };
 
+static const char *ALLOWED_FW_12[] __initconst = { 
+    "1543EMS1.113", 
+	NULL 
+};
+
+static struct msi_ec_conf CONF12 __initdata = {
+	.allowed_fw = ALLOWED_FW_12,
+	.charge_control = {
+		.address = 0XD7,
+		.offset_start = 0x8a,
+        .offset_end   = 0x80,
+        .range_min    = 0x8a,
+        .range_max    = 0xe4,
+	},
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = MSI_EC_ADDR_UNSUPP,
+		.bit           = 1,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.fn_win_swap = {
+        .address = 0xe8,
+        .bit     = 4,
+    },
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 },
+			{ SM_COMFORT_NAME, 0xc1 },
+			{ SM_SPORT_NAME,   0xc0 },
+			{ SM_TURBO_NAME,   0xc4 },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+        .address = 0xeb,
+        .mask = 0x0f,
+    },
+	.fan_mode = {
+        .address = 0xd4,
+        .modes = {
+            { FM_AUTO_NAME,     0x0d },
+            { FM_SILENT_NAME,   0x1d },
+            { FM_ADVANCED_NAME, 0x8d },
+            MSI_EC_MODE_NULL
+        },
+    },
+	.cpu = {
+		.rt_temp_address       = 0x68,
+		.rt_fan_speed_address  = 0xc9, // ?
+		.rt_fan_speed_base_min = 0x19,
+		.rt_fan_speed_base_max = 0x96,
+		.bs_fan_speed_address  = MSI_EC_ADDR_UNKNOWN, // ?
+		.bs_fan_speed_base_min = 0x00,
+		.bs_fan_speed_base_max = 0x0f,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0x89,
+	},
+	.leds = {
+        .micmute_led_address = MSI_EC_ADDR_UNKNOWN,
+        .mute_led_address    = MSI_EC_ADDR_UNKNOWN,
+        .bit                 = 1,
+    },
+    .kbd_bl = {
+        .bl_mode_address  = MSI_EC_ADDR_UNKNOWN,
+        .bl_modes         = {}, // ?
+        .max_mode         = 1, // ?
+        .bl_state_address = 0xd3,
+        .state_base_value = 0x80,
+        .max_state        = 3,
+    },
+
+
+};
+
+
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -1008,6 +1090,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF9,
 	&CONF10,
 	&CONF11,
+	&CONF12,
 	NULL
 };
 


### PR DESCRIPTION
This pull request adds support for msi gp66-11ug, I am guessing that this commit should work with other gp66-11u variants and gp76-11u variants.