### PR TITLE
msi-ec: Add Summit E14Evo new firmware

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -689,6 +689,7 @@ static struct msi_ec_conf CONF7 __initdata = {
 
 static const char *ALLOWED_FW_8[] __initconst = {
 	"14F1EMS1.115",
+	"14F1EMS1.116",
 	NULL
 };
 


### PR DESCRIPTION
Added a new firmware version: 14F1EMS1.116

On latest BIOS version released on 03/07/2023 msi_ec is not allowed to load.

```
$ modprobe -v msi_ec
modprobe: ERROR: could not insert 'msi_ec': Operation not supported

$ journalctl -k | grep "msi_ec\|E14F1IMS"
kernel: DMI: Micro-Star International Co., Ltd. Summit E14Evo A12M/MS-14F1, BIOS E14F1IMS.114 03/07/2023
kernel: msi_ec: Firmware version is not supported: '14F1EMS1.116'
```