### PR TITLE
Add `Katana 17 B11UCX (17L2EMS1)` support

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,3 +240,4 @@ Set this parameter to a supported EC firmware version to use its configuration a
 - Katana GF66 11UC / 11UD (1582EMS1)
 - Prestige 15 A11SCX (16S6EMS1)
 - Alpha 17 B5EEK (17LLEMS1)
+- Katana 17 B11UCX (17L2EMS1)

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1148,6 +1148,95 @@ static struct msi_ec_conf CONF13 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_14[] __initconst = {
+	"17L2EMS1.108", // Katana 17 B11UCX-897X
+	NULL
+};
+
+static struct msi_ec_conf CONF14 __initdata = {
+	.allowed_fw = ALLOWED_FW_14,
+	.charge_control = {
+		.address      = 0xd7,
+		.offset_start = 0x8a,
+		.offset_end   = 0x80,
+		.range_min    = 0x8a,
+		.range_max    = 0xe4,
+	},
+	// .usb_share  {
+	// 	.address      = 0xbf, // states: 0x08 || 0x28
+	// 	.bit          = 5,
+	// }
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8, // states: 0x40 || 0x50
+		.bit     = 4,
+	},
+	.cooler_boost = {
+		.address = 0x98, // states: 0x02 || 0x82
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2, // Performance Level
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 }, // Low
+			{ SM_COMFORT_NAME, 0xc1 }, // Medium
+			{ SM_SPORT_NAME,   0xc0 }, // High
+			{ SM_TURBO_NAME,   0xc4 }, // Turbo
+			MSI_EC_MODE_NULL
+			
+		},
+	},
+	.super_battery = {
+		.address = MSI_EC_ADDR_UNSUPP, // enabled by Low Performance Level
+		// .address = 0xeb, // states: 0x00 || 0x0f
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address       = 0x68,
+		.rt_fan_speed_address  = 0xc9,
+		.rt_fan_speed_base_min = 0x00, // ?
+		.rt_fan_speed_base_max = 0x96, // ?
+		.bs_fan_speed_address  = MSI_EC_ADDR_UNSUPP,
+		.bs_fan_speed_base_min = 0x00, // ?
+		.bs_fan_speed_base_max = 0x0f, // ?
+		// .rt_temp_table_start_adress = 0x6a,
+		// .rt_fan_speed_table_start_address = 0x72,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0xcb,
+		// .rt_temp_table_start_adress = 0x82,
+		// .rt_fan_speed_table_start_address = 0x8a,
+	},
+	.leds = {
+		.micmute_led_address = 0x2c, // states: 0x00 || 0x02
+		.mute_led_address    = 0x2d, // states: 0x04 || 0x06
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		// .bl_mode_address  = 0x2c, // ?
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
+		.bl_modes         = { 0x00, 0x08 }, // ? always on; off after 10 sec
+		.max_mode         = 1, // ?
+		.bl_state_address = 0xd3,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -1163,6 +1252,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF11,
 	&CONF12,
 	&CONF13,
+	&CONF14,
 	NULL
 };
 


### PR DESCRIPTION
_Something went wrong with the previous pull request. I'm duplicating it here._

device: `MSI Katana 17 B11UCX-897XRU`
 *-family: `GF`
 *-version: `REV:1.0`

motherboard: `MS-17L2`
 *-firmware: `E17L2IMS.317`

CPU: `11th Gen Intel(R) Core(TM) i5-11260H @ 2.60GHz`
iGPU: `TigerLake-H GT1 [UHD Graphics]`
dGPU: `GA107 [GeForce RTX 2050]`

EC firmware version: `17L2EMS1.108`

EC_dump in default state:
```
     | _0 _1 _2 _3 _4 _5 _6 _7 _8 _9 _a _b _c _d _e _f
-----+------------------------------------------------
0x0_ | 00 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x1_ | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x2_ | 00 00 00 00 00 00 00 00 0a 05 00 00 00 04 0b 0b
0x3_ | 02 05 00 0d 00 00 50 81 d2 11 88 2c c8 01 c0 00
0x4_ | f8 11 36 00 cb 11 90 fb 78 09 04 2c c1 0b fa 32
0x5_ | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x6_ | 00 00 00 00 00 00 00 00 25 00 37 40 49 4c 52 58
0x7_ | 64 26 26 2b 30 36 3c 46 55 64 08 03 03 03 03 03
0x8_ | 00 00 37 3d 43 49 4f 54 63 00 00 2b 30 36 3c 46
0x9_ | 55 64 08 03 03 03 03 02 02 0f 7d 02 0a 78 32 00
0xa_ | 31 37 4c 32 45 4d 53 31 2e 31 30 38 30 34 31 30
0xb_ | 32 30 32 33 31 33 3a 34 34 3a 34 32 00 00 00 08
0xc_ | 00 00 01 25 00 00 00 00 00 d3 00 00 00 00 00 00
0xd_ | 00 00 c1 81 0d 00 05 bc 00 01 00 00 00 00 00 00
0xe_ | e2 00 00 cb 11 00 00 40 40 00 00 00 00 d1 00 00
0xf_ | 00 00 70 00 00 64 00 00 64 00 00 00 00 00 00 00
```


EC_dump in `charging` + `cooler_boost` + `micmute_led` is on + `kbd_bl` is off + `webcam` is off :
```
     | _0 _1 _2 _3 _4 _5 _6 _7 _8 _9 _a _b _c _d _e _f
-----+------------------------------------------------
0x0_ | 00 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x1_ | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x2_ | 00 00 00 00 00 00 00 00 0a 05 00 00 02 04 09 0b
0x3_ | 03 01 00 0d 01 00 50 81 d2 11 88 2c c8 01 c0 00
0x4_ | f8 11 34 00 cb 11 00 00 2d 09 fa 2c ca 0b fa 32
0x5_ | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x6_ | 00 00 00 00 00 00 00 00 26 00 37 40 49 4c 52 58
0x7_ | 64 26 26 2b 30 36 3c 46 55 64 08 03 03 03 03 03
0x8_ | 21 00 37 3d 43 49 4f 54 63 00 00 2b 30 36 3c 46
0x9_ | 55 64 08 03 03 03 03 02 82 0f 7d 02 0a 78 35 00
0xa_ | 31 37 4c 32 45 4d 53 31 2e 31 30 38 30 34 31 30
0xb_ | 32 30 32 33 31 33 3a 34 34 3a 34 32 00 00 00 08
0xc_ | 00 00 01 25 00 00 00 00 00 54 00 51 00 00 00 00
0xd_ | 00 00 c1 80 0d 00 05 bc 00 01 00 00 00 00 00 00
0xe_ | e2 00 00 cb 11 00 00 40 40 00 00 00 00 c0 00 00
0xf_ | 00 00 70 00 00 64 00 00 64 00 00 00 00 00 00 00
```

After several weeks of use, no critical problems were noticed. The functions documented by the driver work correctly.

Noticed discrepancy in items `../fn_key` and `../win_key`. The states indicated in them are in fact inverted.