### PR TITLE
Added support for MSI GS66 12UGS

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1636,6 +1636,87 @@ static struct msi_ec_conf CONF19 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_20[] __initconst = {
+	"16V5EMS1.107", // MSI GS66 12UGS
+	NULL
+};
+
+static struct msi_ec_conf CONF20 __initdata = {
+	.allowed_fw = ALLOWED_FW_20,
+	.charge_control = {
+		.address      = 0xd7,
+		.offset_start = 0x8a,
+		.offset_end   = 0x80,
+		.range_min    = 0x8a,
+		.range_max    = 0xe4,
+	},
+	// .usb_share  {
+	// 	.address      = 0xbf,
+	// 	.bit          = 5,
+	// },
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 }, // super battery
+			{ SM_COMFORT_NAME, 0xc1 }, // balanced
+			{ SM_TURBO_NAME,   0xc4 }, // extreme
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xeb,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address       = 0x68,
+		.rt_fan_speed_address  = MSI_EC_ADDR_UNKNOWN, // 0xc9
+		.rt_fan_speed_base_min = 0x00, // ?
+		.rt_fan_speed_base_max = 0x3d, // ?
+		.bs_fan_speed_address  = MSI_EC_ADDR_UNKNOWN, // 0xcd
+		.bs_fan_speed_base_min = 0x00, // ?
+		.bs_fan_speed_base_max = 0x0f, // ?
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0xcb,
+	},
+	.leds = {
+		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
+		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
+		.bl_modes         = { },
+		.max_mode         = 1,
+		.bl_state_address = MSI_EC_ADDR_UNSUPP,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -1657,6 +1738,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF17,
 	&CONF18,
 	&CONF19,
+    	&CONF20,
 	NULL
 };
 


### PR DESCRIPTION
### Laptop Model
MSI GS66 12UGS

### EC firmware version
16V5EMS1.107

### EC memory dump
```
     | _0 _1 _2 _3 _4 _5 _6 _7 _8 _9 _a _b _c _d _e _f
-----+------------------------------------------------
0x0_ | 00 80 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x1_ | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x2_ | 00 00 00 00 00 00 00 00 0a 05 00 00 00 04 3b 4b
0x3_ | 03 09 00 0d 03 00 50 81 6a 18 60 3b 71 02 e0 00
0x4_ | 00 00 62 00 81 14 00 00 fb 13 ae 40 1c 0c 00 00
0x5_ | 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
0x6_ | 00 00 00 00 00 00 00 00 3d 00 37 3c 41 46 5a 5f
0x7_ | 64 41 2d 32 3c 41 50 55 64 00 08 07 05 05 05 03
0x8_ | 37 00 32 3c 46 52 5a 5d 64 2d 00 2d 3c 46 50 55
0x9_ | 64 00 03 05 05 06 03 03 02 0f 78 02 0f 78 3e 00
0xa_ | 31 36 56 35 45 4d 53 31 2e 31 30 37 31 32 31 34
0xb_ | 32 30 32 32 31 35 3a 33 30 3a 31 37 00 00 00 08
0xc_ | 00 00 07 25 00 00 00 00 00 9b 00 9d 00 c0 00 00
0xd_ | 00 00 c1 83 0d 00 05 80 00 01 00 00 00 08 00 00
0xe_ | e2 00 00 81 14 01 00 40 00 00 00 00 00 c2 00 00
0xf_ | 00 00 70 00 36 7f 05 37 41 00 03 c0 00 03 01 00
```
### GPU
Intel & Nvidia

### Is your keyboard RGB?
Per key RGB

### Additional context
Both `rt_temp_address` and `bs_fan_speed_address` are valid addresses but need tweak the `base_min` and `base_max` values. Keyboard backlighting control isn't working, it seems to be controlled by Steelseries GG. Also, FN key swap returns opposite values.