### PR TITLE
Support for Katana GF76-11UC, 17L2EMS1.108

### DIFF
--- a/ec_memory_configuration.h
+++ b/ec_memory_configuration.h
@@ -63,11 +63,18 @@ struct msi_ec_fan_mode_conf {
 	struct msi_ec_mode modes[5]; // fixed size for easier hard coding
 };
 
+#define FAN_PARSE_STRATEGY_NORMAL 0
+// When fan speed specified in reverse order 
+// 0xff - minimal speed, 0x01 - maximum and 0x00 - stopped.
+#define FAN_PARSE_STRATEGY_REVERSE 1
 struct msi_ec_cpu_conf {
 	int rt_temp_address;
 	int rt_fan_speed_address; // realtime
 	int rt_fan_speed_base_min;
 	int rt_fan_speed_base_max;
+	// For special fan speed parsing cases
+	// Optional parameter. Defaults to FAN_PARSE_STRATEGY_NORMAL.
+	int rt_fan_parse_strategy; 
 	int bs_fan_speed_address; // basic
 	int bs_fan_speed_base_min;
 	int bs_fan_speed_base_max;

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3235,6 +3235,11 @@ static enum led_brightness kbd_bl_sysfs_get(struct led_classdev *led_cdev)
 static int kbd_bl_sysfs_set(struct led_classdev *led_cdev,
 			    enum led_brightness brightness)
 {
+	// By default, on an unregister event, 
+	// kernel triggers the setter with 0 brightness.
+	if (led_cdev->flags & LED_UNREGISTERING) 
+		return 0;
+
 	u8 wdata;
 	if (brightness < 0 || brightness > 3)
 		return -1;


### PR DESCRIPTION
Support Katana GF76-11UC (#138)

List of changes: 
- **[Support for reverse fan speed.](https://github.com/BeardOverflow/msi-ec/pull/139/commits/0bd5dae9fda187ed9241e17a32ae42b913eb9502)**  
On tihs platform fan speed is reversed (more value in ec -> less fan speed). This PR adds a workaround for this problem without break of existing APIs.  
A one problem keeps: In fact fan speed takes 2 bytes (for me, 0xc8 and 0xc9) but the module supports only one byte (0xc9). 
On my laptop CPU fan speed is inversed so when fan gets slow it turns out to be (0x00 0xfa -> 0x00 0xff -> 0x01 0x08) Which may lead to EINVAL (when it reads 0x08 and compares it with maximum speed). But this is not critical because such a big value is reported for about 1 second and only when fan is about to stop and become 0x00 0x00.
- **[Fix keyboard brightness reset on module exit.](https://github.com/BeardOverflow/msi-ec/pull/139/commits/e579abfeaf42f74d8a2f7c6869453ac8bb1c1c31)**
By default kernel triggers the setter on led_classdev_unregister which
leads to keyboard brightness reset (the keyboard backlight turns off).
This behavior may cause resets every system reboot. Also it's quite
annoying in development.