### PR TITLE
Add new EC versions

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -702,6 +702,8 @@ static const char *ALLOWED_FW_8[] __initconst = {
 	"14F1EMS1.116",
 	"14F1EMS1.117",
 	"14F1EMS1.118",
+	"14F1EMS1.119",
+	"14F1EMS1.120",
 	NULL
 };
 


### PR DESCRIPTION
Adds new versions for Summit E14 Flip Evo A12M. 120 was introduced in June's BIOS update, no mention of any changes in the changelog, everything I tested seems to work fine, I assume 119 won't be different but can't test that

Information from #24