### PR TITLE
Add support for MSI Modern 14 B5M-071XTR

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -2138,6 +2138,84 @@ static struct msi_ec_conf CONF25 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_26[] __initconst = {
+	"14DLEMS1.105", // Modern 14 B5M
+	NULL
+};
+
+static struct msi_ec_conf CONF26 __initdata = {
+	.allowed_fw = ALLOWED_FW_26, // WMI1 based
+	.charge_control = {
+		.address      = 0xef,
+		.offset_start = 0x8a,
+		.offset_end   = 0x80,
+		.range_min    = 0xbc,
+		.range_max    = 0xe4,
+	},
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xbf,
+		.bit     = 4,
+		.invert  = false,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xf2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 }, // Super Battery
+			{ SM_COMFORT_NAME, 0xc1 }, // Silent / Balanced / AI
+			{ SM_SPORT_NAME,   0xc0 }, // Performance
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = MSI_EC_ADDR_UNSUPP, // 0x33 switches between 0x0D and 0x05 
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address       = 0x68,
+		.rt_fan_speed_address  = 0xcd,
+		.rt_fan_speed_base_min = 0x19,
+		.rt_fan_speed_base_max = 0x37,
+		.bs_fan_speed_address  = MSI_EC_ADDR_UNSUPP,
+		.bs_fan_speed_base_min = 0x00,
+		.bs_fan_speed_base_max = 0x0f,
+	},
+	.gpu = {
+		.rt_temp_address      = MSI_EC_ADDR_UNSUPP,
+		.rt_fan_speed_address = MSI_EC_ADDR_UNSUPP,
+	},
+	.leds = {
+		.micmute_led_address = 0x2b,
+		.mute_led_address    = 0x2c,
+		.bit                 = 2,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP, // not presented in MSI app
+		.bl_modes         = { 0x00, 0x08 },
+		.max_mode         = 1,
+		.bl_state_address = 0xf3,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -2165,6 +2243,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF23,
 	&CONF24,
 	&CONF25,
+	&CONF26,
 	NULL
 };
 


### PR DESCRIPTION
https://github.com/BeardOverflow/msi-ec/issues/124

Looks like B5M-071XTR and B5M-224XES has the same specifications. They may be compatible but requires further testing.

I managed to find most of the required adresses but it still requires some work to do (like super battery address).

Force pushes are expected.