### PR TITLE
fix type to compile for Kernel 6.11

### DIFF
--- a/6.11-kernel.patch
+++ b/6.11-kernel.patch
@@ -1,0 +1,22 @@
+diff --git a/msi-ec.c b/msi-ec.c
+index 830cdf4..80ce756 100644
+--- a/msi-ec.c
++++ b/msi-ec.c
+@@ -3562,7 +3562,7 @@ static int msi_platform_probe(struct platform_device *pdev)
+ 	return sysfs_create_groups(&pdev->dev.kobj, msi_platform_groups);
+ }
+ 
+-static int msi_platform_remove(struct platform_device *pdev)
++static void msi_platform_remove(struct platform_device *pdev)
+ {
+ 	if (debug)
+ 		sysfs_remove_group(&pdev->dev.kobj, &msi_debug_group);
+@@ -3573,8 +3573,6 @@ static int msi_platform_remove(struct platform_device *pdev)
+ 		kfree(msi_cpu_group.attrs);
+ 		kfree(msi_gpu_group.attrs);
+ 	}
+-
+-	return 0;
+ }
+ 
+ static struct platform_device *msi_platform_device;

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ obj-m += msi-ec.o
 
 all: modules
 
+6.11-kernel-patch:
+	git apply 6.11-kernel.patch
+
 older-kernel-patch:
 	git apply older-kernel.patch
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Check if your device is supported before attempting to install and use the drive
    - For Arch:   `sudo pacman -S --needed base-devel linux-headers`
 2. Clone this repository and cd to it: `git clone https://github.com/BeardOverflow/msi-ec && cd msi-ec`   
 3. (Linux < 6.2 only, verify with `uname -r`): `make older-kernel-patch`
-4. Choose one of the following installation methods
+4. (Linux >= 6.11) `make 6.11-kernel-patch`
+5. Choose one of the following installation methods
 
 #### (Recommended) Installation using [DKMS](https://en.wikipedia.org/wiki/Dynamic_Kernel_Module_Support):
 


### PR DESCRIPTION
6.10 - https://www.kernel.org/doc/html/v6.10-rc3/driver-api/driver-model/platform.html#platform-drivers

```
 int (*remove)(struct platform_device *);
```
changed to

```
void (*remove)(struct platform_device *);
```
in the latest Linux kernel (6.11)


6.11 - https://www.kernel.org/doc/html/latest/driver-api/driver-model/platform.html#platform-drivers

```
struct platform_driver {
      int (*probe)(struct platform_device *);
      void (*remove)(struct platform_device *);
      void (*shutdown)(struct platform_device *);
      int (*suspend)(struct platform_device *, pm_message_t state);
      int (*resume)(struct platform_device *);
      struct device_driver driver;
      const struct platform_device_id *id_table;
      bool prevent_deferred_probe;
      bool driver_managed_dma;
};
```