### PR TITLE
Use attribute_group.is_visible to hide unsupported attributes

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -4187,50 +4187,6 @@ static struct attribute *msi_root_attrs[] = {
 	NULL
 };
 
-static umode_t msi_root_is_visible(struct kobject *kobj,
-				   struct attribute *attr,
-				   int idx)
-{
-	int address;
-
-	if (attr == &dev_attr_webcam.attr)
-		address = conf.webcam.address;
-
-	else if (attr == &dev_attr_webcam_block.attr)
-		address = conf.webcam.block_address;
-
-	else if (attr == &dev_attr_fn_key.attr ||
-		 attr == &dev_attr_win_key.attr)
-		address = conf.fn_win_swap.address;
-
-	else if (attr == &dev_attr_battery_mode.attr)
-		address = conf.charge_control.address;
-
-	else if (attr == &dev_attr_cooler_boost.attr)
-		address = conf.cooler_boost.address;
-
-	else if (attr == &dev_attr_available_shift_modes.attr ||
-		 attr == &dev_attr_shift_mode.attr)
-		address = conf.shift_mode.address;
-
-	else if (attr == &dev_attr_super_battery.attr)
-		address = conf.super_battery.address;
-
-	else if (attr == &dev_attr_available_fan_modes.attr ||
-		 attr == &dev_attr_fan_mode.attr)
-		address = conf.fan_mode.address;
-
-	else
-		return attr->mode;
-
-	return address == MSI_EC_ADDR_UNSUPP ? 0 : attr->mode;
-}
-
-static struct attribute_group msi_root_group = {
-	.is_visible = msi_root_is_visible,
-	.attrs = msi_root_attrs,
-};
-
 // ============================================================ //
 // Sysfs platform device attributes (cpu)
 // ============================================================ //
@@ -4396,6 +4352,12 @@ static struct device_attribute dev_attr_gpu_realtime_fan_speed = {
 	.show = gpu_realtime_fan_speed_show,
 };
 
+static struct attribute *msi_gpu_attrs[] = {
+	&dev_attr_gpu_realtime_temperature.attr,
+	&dev_attr_gpu_realtime_fan_speed.attr,
+	NULL
+};
+
 // ============================================================ //
 // Sysfs platform device attributes (debug)
 // ============================================================ //
@@ -4520,49 +4482,96 @@ static struct attribute *msi_debug_attrs[] = {
 	NULL
 };
 
+// ============================================================ //
+// Sysfs platform driver
+// ============================================================ //
+
+static umode_t msi_ec_is_visible(struct kobject *kobj,
+				   struct attribute *attr,
+				   int idx)
+{
+	int address;
+
+	/* root group */
+	if (attr == &dev_attr_webcam.attr)
+		address = conf.webcam.address;
+
+	else if (attr == &dev_attr_webcam_block.attr)
+		address = conf.webcam.block_address;
+
+	else if (attr == &dev_attr_fn_key.attr ||
+		 attr == &dev_attr_win_key.attr)
+		address = conf.fn_win_swap.address;
+
+	else if (attr == &dev_attr_battery_mode.attr)
+		address = conf.charge_control.address;
+
+	else if (attr == &dev_attr_cooler_boost.attr)
+		address = conf.cooler_boost.address;
+
+	else if (attr == &dev_attr_available_shift_modes.attr ||
+		 attr == &dev_attr_shift_mode.attr)
+		address = conf.shift_mode.address;
+
+	else if (attr == &dev_attr_super_battery.attr)
+		address = conf.super_battery.address;
+
+	else if (attr == &dev_attr_available_fan_modes.attr ||
+		 attr == &dev_attr_fan_mode.attr)
+		address = conf.fan_mode.address;
+
+	/* cpu group */
+	else if (attr == &dev_attr_cpu_realtime_temperature.attr)
+		address = conf.cpu.rt_temp_address;
+
+	else if (attr == &dev_attr_cpu_realtime_fan_speed.attr)
+		address = conf.cpu.rt_fan_speed_address;
+
+	else if (attr == &dev_attr_cpu_basic_fan_speed.attr)
+		address = conf.cpu.bs_fan_speed_address;
+
+	/* gpu group */
+	else if (attr == &dev_attr_gpu_realtime_temperature.attr)
+		address = conf.gpu.rt_temp_address;
+
+	else if (attr == &dev_attr_gpu_realtime_fan_speed.attr)
+		address = conf.gpu.rt_fan_speed_address;
+
+	/* default */
+	else
+		return attr->mode;
+
+	return address == MSI_EC_ADDR_UNSUPP ? 0 : attr->mode;
+}
+
+static struct attribute_group msi_root_group = {
+	.is_visible = msi_ec_is_visible,
+	.attrs = msi_root_attrs,
+};
+
+static struct attribute_group msi_cpu_group = {
+	.name = "cpu",
+	.is_visible = msi_ec_is_visible,
+	.attrs = msi_cpu_attrs,
+};
+static struct attribute_group msi_gpu_group = {
+	.name = "gpu",
+	.is_visible = msi_ec_is_visible,
+	.attrs = msi_gpu_attrs,
+};
+
 static const struct attribute_group msi_debug_group = {
 	.name = "debug",
 	.attrs = msi_debug_attrs,
 };
 
-// ============================================================ //
-// Sysfs platform driver
-// ============================================================ //
-
-static struct attribute_group msi_cpu_group = {
-	.name = "cpu",
-};
-static struct attribute_group msi_gpu_group = {
-	.name = "gpu",
-};
-
+/* the debug group is created separately if needed */
 static const struct attribute_group *msi_platform_groups[] = {
 	&msi_root_group,
 	&msi_cpu_group,
 	&msi_gpu_group,
 	NULL
 };
-
-/*
- * Creates an array of supported attributes
- * Return value has to be freed manually
-*/
-static struct attribute **filter_attributes(struct attribute_support *attributes,
-					    size_t size)
-{
-	struct attribute **filtered =
-		kcalloc(size + 1, sizeof(struct attribute *), GFP_KERNEL);
-	if (!filtered)
-		return NULL;
-
-	// copy supported attributes only
-	for (int i = 0, j = 0; i < size; i++) {
-		if (attributes[i].supported)
-			filtered[j++] = attributes[i].attribute;
-	}
-
-	return filtered;
-}
 
 static int msi_platform_probe(struct platform_device *pdev)
 {
@@ -4571,52 +4580,10 @@ static int msi_platform_probe(struct platform_device *pdev)
 						&msi_debug_group);
 		if (result < 0)
 			return result;
-
-		if (!conf_loaded) // debug mode on an unsupported device
-			return 0;
 	}
 
-	/* cpu group */
-
-	struct attribute_support cpu_attrs_support[] = {
-		{
-			&dev_attr_cpu_realtime_temperature.attr,
-			conf.cpu.rt_temp_address != MSI_EC_ADDR_UNSUPP,
-		},
-		{
-			&dev_attr_cpu_realtime_fan_speed.attr,
-			conf.cpu.rt_fan_speed_address != MSI_EC_ADDR_UNSUPP,
-		},
-		{
-			&dev_attr_cpu_basic_fan_speed.attr,
-			conf.cpu.bs_fan_speed_address != MSI_EC_ADDR_UNSUPP,
-		},
-	};
-
-	msi_cpu_group.attrs =
-		filter_attributes(cpu_attrs_support,
-				  sizeof(cpu_attrs_support) / sizeof(cpu_attrs_support[0]));
-	if (!msi_cpu_group.attrs)
-		return -ENOMEM;
-
-	/* gpu group */
-
-	struct attribute_support gpu_attrs_support[] = {
-		{
-			&dev_attr_gpu_realtime_temperature.attr,
-			conf.gpu.rt_temp_address != MSI_EC_ADDR_UNSUPP,
-		},
-		{
-			&dev_attr_gpu_realtime_fan_speed.attr,
-			conf.gpu.rt_fan_speed_address != MSI_EC_ADDR_UNSUPP,
-		},
-	};
-
-	msi_gpu_group.attrs =
-		filter_attributes(gpu_attrs_support,
-				  sizeof(gpu_attrs_support) / sizeof(gpu_attrs_support[0]));
-	if (!msi_gpu_group.attrs)
-		return -ENOMEM;
+	if (!conf_loaded) // an unsupported device loaded in debug mode
+		return 0;
 
 	return sysfs_create_groups(&pdev->dev.kobj, msi_platform_groups);
 }
@@ -4630,12 +4597,8 @@ static int msi_platform_remove(struct platform_device *pdev)
 	if (debug)
 		sysfs_remove_group(&pdev->dev.kobj, &msi_debug_group);
 
-	if (conf_loaded) {
+	if (conf_loaded)
 		sysfs_remove_groups(&pdev->dev.kobj, msi_platform_groups);
-		kfree(msi_root_group.attrs);
-		kfree(msi_cpu_group.attrs);
-		kfree(msi_gpu_group.attrs);
-	}
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0))
 	return 0;


### PR DESCRIPTION
Instead of dynamically allocating the attribute lists and copying the arrays of attributes, use the custom is_visible function natively supported by sysfs. This also leaves no dynamic memory management in the code, avoiding potential memory issues. The is_visible function is implemented in a similar way to the ASUS and Ideapad drivers' implementations