### PR TITLE
Getting the platform driver ready for upstream

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3880,6 +3880,8 @@ static ssize_t fn_key_show(struct device *device, struct device_attribute *attr,
 	bool bit_value;
 
 	result = ec_check_bit(conf.fn_win_swap.address, conf.fn_win_swap.bit, &bit_value);
+	if (result < 0)
+		return result;
 
 	if (bit_value ^ conf.fn_win_swap.invert) {
 		return sysfs_emit(buf, "%s\n", "right");
@@ -3916,6 +3918,8 @@ static ssize_t win_key_show(struct device *device,
 	bool bit_value;
 
 	result = ec_check_bit(conf.fn_win_swap.address, conf.fn_win_swap.bit, &bit_value);
+	if (result < 0)
+		return result;
 
 	if (bit_value ^ conf.fn_win_swap.invert) {
 		return sysfs_emit(buf, "%s\n", "left");
@@ -3997,6 +4001,8 @@ static ssize_t cooler_boost_show(struct device *device,
 	bool bit_value;
 
 	result = ec_check_bit(conf.cooler_boost.address, conf.cooler_boost.bit, &bit_value);
+	if (result < 0)
+		return result;
 
 	if (bit_value) {
 		return sysfs_emit(buf, "%s\n", "on");
@@ -4102,6 +4108,8 @@ static ssize_t super_battery_show(struct device *device,
 	result = ec_check_by_mask(conf.super_battery.address,
 				  conf.super_battery.mask,
 				  &enabled);
+	if (result < 0)
+		return result;
 
 	if (enabled) {
 		return sysfs_emit(buf, "%s\n", "on");
@@ -4783,9 +4791,8 @@ static int __init load_configuration(void)
 	} else {
 		// get fw version from EC
 		result = ec_get_firmware_version(ver_by_ec);
-		if (result < 0) {
+		if (result < 0)
 			return result;
-		}
 
 		ver = ver_by_ec;
 	}

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3567,12 +3567,6 @@ MODULE_PARM_DESC(debug, "Load the driver in the debug mode, exporting the debug 
 // Helper functions
 // ============================================================ //
 
-#define streq(x, y) (strcmp(x, y) == 0 || strcmp(x, y "\n") == 0)
-
-#define set_bit(v, b)   (v |= (1 << b))
-#define unset_bit(v, b) (v &= ~(1 << b))
-#define check_bit(v, b) ((bool)((v >> b) & 1))
-
 static int ec_read_seq(u8 addr, u8 *buf, u8 len)
 {
 	int result;
@@ -3645,9 +3639,9 @@ static int ec_set_bit(u8 addr, u8 bit, bool value)
 		goto unlock;
 
 	if (value)
-		set_bit(stored, bit);
+		stored |= BIT(bit);
 	else
-		unset_bit(stored, bit);
+		stored &= ~BIT(bit);
 
 	result = ec_write(addr, stored);
 
@@ -3665,7 +3659,7 @@ static int ec_check_bit(u8 addr, u8 bit, bool *output)
 	if (result < 0)
 		return result;
 
-	*output = check_bit(stored, bit);
+	*output = stored & BIT(bit);
 
 	return 0;
 }
@@ -3899,11 +3893,11 @@ static ssize_t fn_key_store(struct device *dev, struct device_attribute *attr,
 {
 	int result;
 
-	if (streq(buf, "right")) {
+	if (sysfs_streq("right", buf)) {
 		result = ec_set_bit(conf.fn_win_swap.address,
 				    conf.fn_win_swap.bit,
 				    true ^ conf.fn_win_swap.invert);
-	} else if (streq(buf, "left")) {
+	} else if (sysfs_streq("left", buf)) {
 		result = ec_set_bit(conf.fn_win_swap.address,
 				    conf.fn_win_swap.bit,
 				    false ^ conf.fn_win_swap.invert);
@@ -3935,11 +3929,11 @@ static ssize_t win_key_store(struct device *dev, struct device_attribute *attr,
 {
 	int result;
 
-	if (streq(buf, "right")) {
+	if (sysfs_streq("right", buf)) {
 		result = ec_set_bit(conf.fn_win_swap.address,
 				    conf.fn_win_swap.bit,
 				    false ^ conf.fn_win_swap.invert);
-	} else if (streq(buf, "left")) {
+	} else if (sysfs_streq("left", buf)) {
 		result = ec_set_bit(conf.fn_win_swap.address,
 				    conf.fn_win_swap.bit,
 				    true ^ conf.fn_win_swap.invert);
@@ -3978,15 +3972,15 @@ static ssize_t battery_mode_store(struct device *dev,
 {
 	int result = -EINVAL;
 
-	if (streq(buf, "max"))
+	if (sysfs_streq("max", buf))
 		result = ec_write(conf.charge_control.address,
 				  conf.charge_control.range_max);
 
-	else if (streq(buf, "medium")) // up to 80%
+	else if (sysfs_streq("medium", buf)) // up to 80%
 		result = ec_write(conf.charge_control.address,
 				  conf.charge_control.offset_end + 80);
 
-	else if (streq(buf, "min")) // up to 60%
+	else if (sysfs_streq("min", buf)) // up to 60%
 		result = ec_write(conf.charge_control.address,
 				  conf.charge_control.offset_end + 60);
 
@@ -4017,12 +4011,12 @@ static ssize_t cooler_boost_store(struct device *dev,
 {
 	int result = -EINVAL;
 
-	if (streq(buf, "on"))
+	if (sysfs_streq("on", buf))
 		result = ec_set_bit(conf.cooler_boost.address,
 				    conf.cooler_boost.bit,
 				    true);
 
-	else if (streq(buf, "off"))
+	else if (sysfs_streq("off", buf))
 		result = ec_set_bit(conf.cooler_boost.address,
 				    conf.cooler_boost.bit,
 				    false);
@@ -4122,11 +4116,11 @@ static ssize_t super_battery_store(struct device *dev,
 {
 	int result = -EINVAL;
 
-	if (streq(buf, "on"))
+	if (sysfs_streq("on", buf))
 		result = ec_set_by_mask(conf.super_battery.address,
 				        conf.super_battery.mask);
 
-	else if (streq(buf, "off"))
+	else if (sysfs_streq("off", buf))
 		result = ec_unset_by_mask(conf.super_battery.address,
 					  conf.super_battery.mask);
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -4568,10 +4568,13 @@ static struct attribute *msi_debug_attrs[] = {
 // ============================================================ //
 
 static umode_t msi_ec_is_visible(struct kobject *kobj,
-				   struct attribute *attr,
-				   int idx)
+				 struct attribute *attr,
+				 int idx)
 {
 	int address;
+
+	if (!conf_loaded)
+		return 0;
 
 	/* root group */
 	if (attr == &dev_attr_webcam.attr)
@@ -4663,10 +4666,7 @@ static int __init msi_platform_probe(struct platform_device *pdev)
 			return result;
 	}
 
-	if (!conf_loaded) // an unsupported device loaded in debug mode
-		return 0;
-
-	return sysfs_create_groups(&pdev->dev.kobj, msi_platform_groups);
+	return 0;
 }
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 11, 0))
@@ -4678,9 +4678,6 @@ static int msi_platform_remove(struct platform_device *pdev)
 	if (debug)
 		sysfs_remove_group(&pdev->dev.kobj, &msi_debug_group);
 
-	if (conf_loaded)
-		sysfs_remove_groups(&pdev->dev.kobj, msi_platform_groups);
-
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(6, 11, 0))
 	return 0;
 #endif
@@ -4691,6 +4688,7 @@ static struct platform_device *msi_platform_device;
 static struct platform_driver msi_platform_driver = {
 	.driver = {
 		.name = MSI_EC_DRIVER_NAME,
+		.dev_groups = msi_platform_groups,
 	},
 	.remove = msi_platform_remove,
 };


### PR DESCRIPTION
- [x] Inline some macros and rework the rest of the strcmp hacks
- [x] Use platform_create_bundle() to register the driver
- [ ] #223
- [ ] ~Write ABI documentation~
- [x] Add missing error handling
- [x] Use str_on_off() and kstrtobool