### PR TITLE
Fix NixOS installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,26 +55,10 @@ Eager to support the project? Your help is always welcome to keep the project al
 2. Run `yay -S msi-ec-git`
 
 ### On NixOS
-The driver is packaged on `nixos-unstable` under the name
-`linuxKernel.packages.<kernel>.msi-ec`.
+Add these lines to your configuration
 ```nix
-# In your config
-
-{
-	# ...
-	boot.kernelPackages = pkgs.linuxPackages_latest // {
-		# Replace linux_6_6 by your actual kernel
-		msi-ec = linuxKernel.packages.linux_6_6.msi-ec;
-	};
-
-	boot.kernelModules = [
-		# ...
-
-		"msi-ec"
-
-		# ...
-	];
-}
+boot.extraModulePackages = [ config.boot.kernelPackages.msi-ec ];
+boot.kernelModules = [ "msi-ec" ];
 ```
 
 


### PR DESCRIPTION
- The current installation instructions can be simplified to adding the module to `boot.extraModulePackages` to install them and then adding the name of the module to `boot.kernelModules` to load it. 
- The module has also reached the latest stable release and as such `nixos-unstable` is also no longer needed.