### PR TITLE
Remove the battery_mode attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,14 +111,6 @@ This driver exports a few files in its own platform device, msi-ec, and is avail
     - left: windows key goes to the left, function key goes to the right
     - right: windows key goes to the right, function key goes to the left
 
-- `/sys/devices/platform/msi-ec/battery_mode`
-  - Description: This entry allows changing the battery mode for health purposes.
-  - Access: Read, Write
-  - Valid values:
-    - max: best for mobility. Charge the battery to 100% all the time
-    - medium: balanced. Charge the battery when under 70%, stop at 80%
-    - min: best for battery. Charge the battery when under 50%, stop at 60%
-
 - `/sys/devices/platform/msi-ec/cooler_boost`
   - Description: This entry allows enabling the cooler boost function. It provides powerful cooling capability by boosting the airflow.
   - Access: Read, Write


### PR DESCRIPTION
It does the same thing that charge_control_(start/end)_threshold already do, just more restricted. Presets, if needed, should be provided by userspace utilities.