### PR TITLE
msi-ec.c: Add Support for GF63-10SC

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -883,6 +883,7 @@ static struct msi_ec_conf CONF11 __initdata = {
 };
 
 static const char *ALLOWED_FW_12[] __initconst = {
+	"16R5EMS1.102", // GF63 Thin 10SC-222
 	"16R6EMS1.104", // GF63 Thin 11UC
 	"16R6EMS1.106",
 	"16R6EMS1.107",


### PR DESCRIPTION
This seems to fully work on my GF63 running pop

auto fan mode actually autos which is nice, and turbo fan mode works too