### PR TITLE
Add support for Raider GE67 HX - 12U

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3161,6 +3161,79 @@ static struct msi_ec_conf CONF44 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_45[] __initconst = {
+	"1545IMS1.109", // Raider GE67 HX - 12U
+	NULL
+};
+
+static struct msi_ec_conf CONF45 __initdata = {
+	.allowed_fw = ALLOWED_FW_45,
+	.charge_control_address = 0xd7,
+	// .usb_share = {
+	//  	.address      = 0xbf, // states: 0x08 (off) || 0x28 (on)
+	//  	.bit          = 5,
+	// },
+	.webcam = {  // no option in msi-center
+		.address       = 0x2e,
+		.block_address = MSI_EC_ADDR_UNSUPP, // not in MSI app
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4,  // 01 or 11
+		.invert  = true,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_COMFORT_NAME, 0xc1 }, // Silent / Balanced / AI
+			{ SM_ECO_NAME,     0xc2 }, // Super Battery
+			{ SM_TURBO_NAME,   0xc4 }, // Performance
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xeb,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x4d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address      = 0x68,
+		.rt_fan_speed_address = 0x71,
+		// Fan rpm is 480000 / value at combined: c8..c9
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0x89,
+		// Fan rpm is 480000 / value at combined: ca..cb
+	},
+	.leds = {
+		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
+		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
+		.bl_modes         = { 0x00, 0x08 },
+		.max_mode         = 1,
+		.bl_state_address = MSI_EC_ADDR_UNSUPP,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -3207,6 +3280,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF42,
 	&CONF43,
 	&CONF44,
+	&CONF45,
 	NULL
 };
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3205,7 +3205,7 @@ static struct msi_ec_conf CONF45 __initdata = {
 		.modes = {
 			{ FM_AUTO_NAME,     0x0d },
 			{ FM_SILENT_NAME,   0x1d },
-			{ FM_ADVANCED_NAME, 0x4d },
+			{ FM_ADVANCED_NAME, 0x8d },
 			MSI_EC_MODE_NULL
 		},
 	},


### PR DESCRIPTION
Laptop model: Raider GE67 HX - 12U
EC Dump:
```
 ❯ sudo hexdump -C /sys/kernel/debug/ec/ec0/io
[sudo] password for ahmed:
00000000  00 80 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  0a 05 00 00 00 00 0b 5b  |...............[|
00000030  83 01 00 0d 01 00 50 81  6a 18 60 3b 71 02 c0 00  |......P.j.`;q...|
00000040  35 0c 4f 00 a3 14 00 00  31 10 99 3e 04 0c f8 43  |5.O.....1..>...C|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  3a 00 32 39 40 47 4e 55  |........:.29@GNU|
00000070  64 19 00 00 0a 19 20 32  50 64 0a 08 08 08 08 08  |d..... 2Pd......|
00000080  37 00 37 3c 41 46 4b 4b  64 0a 00 00 0a 19 1f 32  |7.7<AFKKd......2|
00000090  55 64 0a 07 06 06 06 06  06 00 00 06 00 00 00 00  |Ud..............|
000000a0  31 35 34 35 49 4d 53 31  2e 31 30 39 31 32 31 31  |1545IMS1.1091211|
000000b0  32 30 32 33 31 33 3a 34  31 3a 32 34 00 00 00 28  |202313:41:24...(|
000000c0  00 00 06 23 00 00 00 00  01 40 02 15 00 00 00 00  |...#.....@......|
000000d0  00 00 c1 03 8d 00 04 d0  00 00 00 00 00 07 00 00  |................|
000000e0  e2 00 00 a3 14 01 00 40  01 00 00 00 00 c2 00 00  |.......@........|
000000f0  00 00 70 00 00 3c 32 00  3c 32 00 00 00 00 00 00  |..p..<2.<2......|
00000100
```