### PR TITLE
Add support for MSI Thin 15 B12VE

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3441,6 +3441,73 @@ static struct msi_ec_conf CONF48 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_49[] __initconst = {
+	"16R8IMS2.112", // MSI Thin 15 B12VE
+	NULL
+};
+
+static struct msi_ec_conf CONF49 __initdata = {
+	.allowed_fw = ALLOWED_FW_49,
+	.charge_control_address = 0xd7,
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = MSI_EC_ADDR_UNSUPP,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4,
+		.invert  = true,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,      0xc2 },
+			{ SM_COMFORT_NAME,  0xc1 },
+			{ SM_TURBO_NAME,    0xc4 },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = MSI_EC_ADDR_UNSUPP,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,      0x0d },
+			{ FM_SILENT_NAME,    0x1d },
+			{ FM_ADVANCED_NAME,  0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address      = 0x68,
+		.rt_fan_speed_address = 0x71,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0x89,
+	},
+	.leds = {
+		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
+		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
+		.bl_modes         = { },
+		.max_mode         = 1,
+		.bl_state_address = 0xd3,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -3491,6 +3558,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF46,
 	&CONF47,
 	&CONF48,
+	&CONF49,
 	NULL
 };
 


### PR DESCRIPTION
Added the following functions:

- Shift modes (Eco, Comfort, Turbo)
- Fan modes (Auto, Advanced)
- CPU Temp & Fan
- GPU Temp & Fan
- Keyboard backlit
- Fn/Win swap
- AC Charging limits