### PR TITLE
Add MSI Titan 18 HX Dragon Edition

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3974,7 +3974,7 @@ static struct msi_ec_conf CONF56 __initdata = {
 	.fn_win_swap = {
 		.address = 0xe8,
 		.bit     = 4, // 0x00 (not flipped) or 0x10 (flipped)
-		.invert  = false,
+		.invert  = true,
 	},
 	.cooler_boost = {
 		.address = 0x98,

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -3954,6 +3954,77 @@ static struct msi_ec_conf CONF55 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_56[] __initconst = {
+	"1824EMS1.107", // Titan 18 HX Dragon Edition
+	NULL
+};
+
+static struct msi_ec_conf CONF56 __initdata = {
+	.allowed_fw = ALLOWED_FW_56,
+	.charge_control_address = 0xd7,
+	// .usb_share  {
+	// 	.address      = 0xbf, // states: 0x08 || 0x28
+	// 	.bit          = 5,
+	// }, // Like Katana 17 B11UCX
+	.webcam = {
+		.address       = MSI_EC_ADDR_UNSUPP, // Manually slide-able cover
+		.block_address = MSI_EC_ADDR_UNSUPP,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4, // 0x00 (not flipped) or 0x10 (flipped)
+		.invert  = false,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7, // 0x02 (off) or 0x82 (on)
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 }, // Eco (Super Battery)
+			{ SM_COMFORT_NAME, 0xc1 }, // Balanced
+			{ SM_TURBO_NAME,   0xc4 }, // Extreme Performance
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xeb, // 0x0f ( on ) or 0x00 ( off )
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address      = 0x68, // Temp in Hex
+		.rt_fan_speed_address = 0x71, // Fan Speed in %
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80, // Temp in Hex
+		.rt_fan_speed_address = 0x89, // Fan Speed in %
+	},
+	.leds = {
+		.micmute_led_address = 0x2c, // off (0x00) or on (0x02)
+		.mute_led_address    = 0x2d, // off (0x24) or on (0x26)
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
+		.bl_modes         = { 0x00, 0x08 }, 
+		.max_mode         = 1,
+		.bl_state_address = MSI_EC_ADDR_UNSUPP, // Technically 0xd3, but its bugged
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -4011,6 +4082,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF53,
 	&CONF54,
 	&CONF55,
+	&CONF56,
 	NULL
 };
 


### PR DESCRIPTION
Implemented to the best of my abilities.

I verified all applicable sys/*** files and they looked correct to me.

```
 nila@dragonair  ~  cat /sys/class/power_supply/BAT1/charge_control_start_threshold
90
 nila@dragonair  ~  cat /sys/class/power_supply/BAT1/charge_control_end_threshold  
100
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/gpu/realtime_fan_speed      
24
 ✘ nila@dragonair  ~  cat /sys/devices/platform/msi-ec/gpu/realtime_temperature
51
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/cpu/realtime_fan_speed
23
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/cpu/realtime_temperature
60
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/fw_release_date
2025-03-28T10:09:43
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/fw_version
1824EMS1.107
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/fan_mode
auto
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/available_fan_modes 
auto
silent
advanced
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/super_battery      
off
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/shift_mode   
comfort
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/available_shift_modes 
eco
comfort
turbo
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/cooler_boost         
off
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/win_key     
left
 nila@dragonair  ~  cat /sys/devices/platform/msi-ec/fn_key 
right
```