### PR TITLE
Add support for MSI Stealth 15M A11UEK (1563EMS1)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -4180,6 +4180,75 @@ static struct msi_ec_conf CONF58 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_59[] __initconst = {
+	"1563EMS1.115", // MSI Stealth 15M A11UEK
+	"1563EMS1.1150105", //Same but complete Firmware
+	NULL
+};
+
+static struct msi_ec_conf CONF59 __initdata = {
+	.allowed_fw = ALLOWED_FW_59, // WMI2 based
+	.charge_control_address = 0xd7,
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4,
+		.invert  = false,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 }, // Super Battery
+			{ SM_COMFORT_NAME, 0xc1 }, // Balanced
+			{ SM_SPORT_NAME,   0xc0 }, // Silent (mas usa nome "sport" internamente)
+			{ SM_TURBO_NAME,   0xc4 }, // High Performance
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xeb,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address      = 0x68,
+		.rt_fan_speed_address = 0x71,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0x89,
+	},
+	.leds = {
+		.micmute_led_address = 0x2c,
+		.mute_led_address    = 0x2d, // 0x2d is the write address but i dont know why is not working
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP, //0x2c
+		.bl_modes         = { 0x00, 0x08 },
+		.max_mode         = 1,
+		.bl_state_address = MSI_EC_ADDR_UNSUPP, //0xd3
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF0,
 	&CONF1,
@@ -4240,6 +4309,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF56,
 	&CONF57,
 	&CONF58,
+	&CONF59,
 	NULL
 };
 


### PR DESCRIPTION
I've successfully added support for the MSI Stealth 15M A11UEK and created a pull request.

## Working features:
- ✅ Shift modes (eco, comfort, sport, turbo) - changes EC values correctly
- ✅ Fan modes (auto, silent, advanced)
- ✅ Cooler boost
- ✅ Temperature monitoring (CPU/GPU)
- ✅ Battery charge threshold
- ✅ Webcam on/off
- ✅ Micmute LED (F5 key)
- ✅ Fn/Win key swap

## Partially working:
- ⚠️ Mute LED (F1 key) - The EC address (0x2d) and bit (1) are correct. The LED can be controlled manually via `/sys/class/leds/platform::mute/brightness` but doesn't respond automatically to the mute key. This might need key mapping configuration.

## Not working:
- ❌ Keyboard backlight control - RGB keyboard is likely controlled via USB, not EC. Marked as `MSI_EC_ADDR_UNSUPP`. Using OpenRGB as alternative.
- ❌ F4 key (touchpad toggle) - Doesn't generate the expected event
- ❌ F7 key (shift mode switcher) - Doesn't cycle through modes automatically, but can be scripted

## Configuration used:
Based on similar WMI2 devices, particularly the GS66 Stealth configuration.

## Manual images for reference:

![Image](https://github.com/user-attachments/assets/11610ebd-ae4a-4fa2-8881-6468a14d81b1)

![Image](https://github.com/user-attachments/assets/1486d389-8acb-4075-bf04-af39ebc9dc4d)

The F7 key is supposed to switch "User Scenario" (shift modes) according to the manual, but doesn't work out of the box. This can be solved with a simple script to cycle through modes.