### PR TITLE
Add cpu and gpu fan_speed_rpm

### DIFF
--- a/ec_memory_configuration.h
+++ b/ec_memory_configuration.h
@@ -58,11 +58,13 @@ struct msi_ec_fan_mode_conf {
 struct msi_ec_cpu_conf {
 	int rt_temp_address;
 	int rt_fan_speed_address; // realtime % RPM
+	int fan_speed_rpm_address_0; // 480000/n RPM
 };
 
 struct msi_ec_gpu_conf {
 	int rt_temp_address;
 	int rt_fan_speed_address; // realtime % RPM
+	int fan_speed_rpm_address_0; // 480000/n RPM
 };
 
 struct msi_ec_led_conf {

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -691,10 +691,12 @@ static struct msi_ec_conf CONF_G1_8 __initdata = {
 	.cpu = {
 		.rt_temp_address      = 0x68,
 		.rt_fan_speed_address = 0x71,
+		.fan_speed_rpm_address_0 = 0xcc,
 	},
 	.gpu = {
 		.rt_temp_address      = 0x80,
 		.rt_fan_speed_address = 0x89,
+		.fan_speed_rpm_address_0 = 0xca,
 	},
 	.leds = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
@@ -2206,6 +2208,23 @@ static ssize_t cpu_realtime_fan_speed_show(struct device *device,
 	return sysfs_emit(buf, "%i\n", rdata);
 }
 
+static ssize_t cpu_fan_speed_rpm_show(struct device *device,
+					       struct device_attribute *attr,
+					       char *buf)
+{
+	u8 rdata[2];
+	int result;
+
+	result = ec_read_seq(conf.cpu.fan_speed_rpm_address_0, rdata, 2);
+	if (result < 0)
+		return result;
+
+	int value = (rdata[0] << 8) | rdata[1];
+	int rpm = value != 0 ? 480000 / value : 0;
+
+	return sysfs_emit(buf, "%i\n", rpm);
+}
+
 static struct device_attribute dev_attr_cpu_realtime_temperature = {
 	.attr = {
 		.name = "realtime_temperature",
@@ -2222,9 +2241,18 @@ static struct device_attribute dev_attr_cpu_realtime_fan_speed = {
 	.show = cpu_realtime_fan_speed_show,
 };
 
+static struct device_attribute dev_attr_cpu_fan_speed_rpm = {
+	.attr = {
+		.name = "fan_speed_rpm",
+		.mode = 0444,
+	},
+	.show = cpu_fan_speed_rpm_show,
+};
+
 static struct attribute *msi_cpu_attrs[] = {
 	&dev_attr_cpu_realtime_temperature.attr,
 	&dev_attr_cpu_realtime_fan_speed.attr,
+	&dev_attr_cpu_fan_speed_rpm.attr,
 	NULL
 };
 
@@ -2260,6 +2288,23 @@ static ssize_t gpu_realtime_fan_speed_show(struct device *device,
 	return sysfs_emit(buf, "%i\n", rdata);
 }
 
+static ssize_t gpu_fan_speed_rpm_show(struct device *device,
+					       struct device_attribute *attr,
+					       char *buf)
+{
+	u8 rdata[2];
+	int result;
+
+	result = ec_read_seq(conf.gpu.fan_speed_rpm_address_0, rdata, 2);
+	if (result < 0)
+		return result;
+
+	int value = (rdata[0] << 8) | rdata[1];
+	int rpm = value != 0 ? 480000 / value : 0;
+
+	return sysfs_emit(buf, "%i\n", rpm);
+}
+
 static struct device_attribute dev_attr_gpu_realtime_temperature = {
 	.attr = {
 		.name = "realtime_temperature",
@@ -2276,9 +2321,18 @@ static struct device_attribute dev_attr_gpu_realtime_fan_speed = {
 	.show = gpu_realtime_fan_speed_show,
 };
 
+static struct device_attribute dev_attr_gpu_fan_speed_rpm = {
+	.attr = {
+		.name = "fan_speed_rpm",
+		.mode = 0444,
+	},
+	.show = gpu_fan_speed_rpm_show,
+};
+
 static struct attribute *msi_gpu_attrs[] = {
 	&dev_attr_gpu_realtime_temperature.attr,
 	&dev_attr_gpu_realtime_fan_speed.attr,
+	&dev_attr_gpu_fan_speed_rpm.attr,
 	NULL
 };
 
@@ -2529,12 +2583,18 @@ static umode_t msi_ec_is_visible(struct kobject *kobj,
 	else if (attr == &dev_attr_cpu_realtime_fan_speed.attr)
 		address = conf.cpu.rt_fan_speed_address;
 
+	else if (attr == &dev_attr_cpu_fan_speed_rpm.attr)
+		address = conf.cpu.fan_speed_rpm_address_0;
+
 	/* gpu group */
 	else if (attr == &dev_attr_gpu_realtime_temperature.attr)
 		address = conf.gpu.rt_temp_address;
 
 	else if (attr == &dev_attr_gpu_realtime_fan_speed.attr)
 		address = conf.gpu.rt_fan_speed_address;
+
+	else if (attr == &dev_attr_gpu_fan_speed_rpm.attr)
+		address = conf.gpu.fan_speed_rpm_address_0;
 
 	/* default */
 	else


### PR DESCRIPTION
Add the fan_speed_rpm entry to use the address 0xcc..0xcd (or 0xc8..0xc9) for CPU fan and 0xca..0xcb for GPU fan, like MControlCenter does.
Discussion with @mutchiko https://github.com/dmitry-s93/MControlCenter/pull/267

## realtime_fan_speed

The current `realtime_fan_speed` (0x71 and 0x89) is the fan % target speed for fan mode.
Ideally, it should include "target", "driving" or "control" in its name.

For example, when cooler boost is enabled, fan mode continues to change the target speed according to the temperature.
- dGPU at D3cold, 0x89 is 0, while fan_speed_rpm indicates 6075 rpm.
- For the CPU fan, the temperature decreases and so does the value at 0x71, while fan_speed_rpm reports 8275.

For now, I named the new value fan_speed_rpm to distinguish both.

## About the magic number 480000
- [MControlCenter uses 470000](https://github.com/dmitry-s93/MControlCenter/blob/7bd388b59398b51215baafe2f6c18d12d4a8cd24/src/operate.cpp#L174)
- [ISW uses 478000](https://github.com/YoyPa/isw/blob/7c88670504ecd4462b1825a55bdb0be2944dfe94/isw#L414)
- Last year, I compared with MSI Center and got `floor(480000/x)` (e.g. target speed at 50% ⇒ read 160 ⇒ 3000 rpm)

But now I wonder if MSI Center report is good. RPM above 4000 seems unreal.
By analyzing the audio with my CPU fan, I get
|target speed|Frequency|480000/n|
|-|-|-|
|50%|1980 Hz|3000 rpm|
|100%|3930 Hz|6000 rpm|
|150%|5470 Hz|8275 rpm|

This is more likely 320000 for my CPU fan, with 100% speed targeting 4000 rpm.

https://download-2.msi.com/archive/mnu_exe/mb/MSICENTER.pdf slide 97, graphs show different RPM at 100% (~2100, 2702, and ~4500). It's also not impossible that they have different numerators, it could be a fan_speed_rpm_magic_number.