### PR TITLE
Add support for MSI Stealth 14 Studio A13VF 14K1EMS1

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1411,6 +1411,76 @@ static struct msi_ec_conf CONF_G2_4 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_G2_5[] __initconst = {
+	"14K1EMS1.103", // Stealth 14 Studio A13VF
+	"14K1EMS1.108",
+	"14K2EMS1.104", // Stealth 14 AI Studio A1VGG / A1VFG
+	"14K2EMS1.107",
+	NULL
+};
+
+static struct msi_ec_conf CONF_G2_5 __initdata = {
+	.allowed_fw = ALLOWED_FW_G2_5, // new
+	.charge_control_address = 0xd7,
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4,
+		.invert  = false,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 },
+			{ SM_COMFORT_NAME, 0xc1 },
+			{ SM_TURBO_NAME,   0xc4 },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xeb,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address      = 0x68,
+		.rt_fan_speed_address = 0x71,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0x89,
+	},
+	.leds = {
+		.micmute_led_address = 0x2c,
+		.mute_led_address    = 0x2d,
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
+		.bl_modes         = { 0x00, 0x08 },
+		.max_mode         = 1,
+		.bl_state_address = MSI_EC_ADDR_UNSUPP,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 static const char *ALLOWED_FW_G2_6[] __initconst = {
 	"16R6EMS1.104", // GF63 Thin 11UC / 11SC
 	"16R6EMS1.106",
@@ -1612,6 +1682,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF_G2_2,
 	&CONF_G2_3,
 	&CONF_G2_4,
+	&CONF_G2_5,
 	&CONF_G2_6,
 	&CONF_G2_10,
 	NULL


### PR DESCRIPTION
close #330 
close #444
close #319 
close #457

new config G2_5 by @glpnk

---

This pull request adds preliminary support for EC Firmware version 14K1EMS1.108 
Relevant Issue(s): #330 #444 

## WORKING

- Mic/Mute LEDs
- Fan Control & CPU/GPU Temp sensors
- Charging support
- FN Super swap functionality

## TODO

- Add webcam support
- Add keyboard backlight support
- Add ECO mode support
- Optionally add support to enable/disable tailgate LEDs
- Refactor added changes to fit msi-ec.c configurations appropriately.
- Revise earlier firmware versions (e.g .103 #444 ) for support. (Downgrading BIOS supported on laptop)

## Notes
Jotted while debugging EC in Windows:
```
2c = tailgate light (00 = OFF, 10 = ON) Bit value? LED Lights look to be in this byte also.
2c = Mic Mute LED (02 = ON)

d2 = shift modes (C4 = Turbo, C1 = Balanced, C2 = Eco)

d4 = fan mode (0D = Normal/Silent(?), 8D = Advanced, ECO = (OD, EB=0F)

2D = Mute LED Bit change, (04 = OFF, 06 = ON)

D8 = FN Key Pressed (OFF = 00, ON = 0B)

D7 = Charge control (100 = E4, 80 = D0, BC = 60 )

D9 = FN Lock ( Bit 2, OFF = 1, ON = 3 )

E8 = FN/Super swap ( OFF = 00, ON = 10 )
```

Relevant issue: #319 - Values listed here correlate heavily/apply with this firmware version.