### PR TITLE
Add support for MSI Stealth 15M A11EUK (1563EMS1.106)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1574,8 +1574,8 @@ static struct msi_ec_conf CONF_G2_6 __initdata = {
 
 static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"1562EMS1.117", // Stealth 15M A11SEK
-	"1563EMS1.115", // Stealth 15M A11UEK
-	"1563EMS1.106", // Stealth 15M A11EUK
+	"1563EMS1.106", // Stealth 15M A11UEK
+	"1563EMS1.115",
 	"1587EMS1.102", // Katana 15 HX B14WEK
 	"15F2EMS1.109", // Stealth 16 Studio A13VG
 	"15F4EMS1.105", // Stealth 16 AI Studio A1VFG


### PR DESCRIPTION
close #265

Added support for MSI Stealth 15M A11EUK, specifically the EC firmware version1563EMS1.106 which wasnt supported.

- EC firmware version: 1563EMS1.106
- This firmware has been tested on my MSI Stealth 15M A11EUK laptop running Linux.
- Verified functionality:
  - Shift modes
  - Fan modes (including silent/advanced)
  - Cooler boost
  - Super battery mode
  - CPU/GPU temperatures
  
<img width="831" height="911" alt="swappy-20251129-214331" src="https://github.com/user-attachments/assets/4fab412b-cfc4-46f1-a12f-87b8a85a94dd" />


