### PR TITLE
feat: Add MSI Raider A18 HX A7VIG 182KIMS1

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1637,6 +1637,7 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"1824EMS1.107", // Titan 18 HX Dragon Edition
 	"182LIMS1.108", // Vector A18 HX A9WHG
 	"182LIMS1.111", // New ec version for Vector A18 HX A9WHG
+	"182KIMS1.113", // Raider A18 HX A7VIG
 	NULL
 };
 


### PR DESCRIPTION
HI!

In case you're interested, this is what I use on my Raider A18 HX A7VIG. It shares a chassis with the other ones here. The fan controls, shift mode, and cooler boost all work properly and temperature readouts seem to be accurate.

One thing that's worth noting is that the webcam controls do not work. I'm guessing this model doesn't have a way to do a software disable on the webcam since it has a hardware shutter, but its also possible that I just didn't find the address for the webcam stuff in my probing.

I figured I'd still offer the patch since webcam seems non-essential when the device otherwise crashes without proper fan support. I've been using this for about a month now and it has prevented the device from crashing. The device crashes a lot during more intensive work if this isn't enabled.

Thanks for the great project!