### PR TITLE
Add MSI Stealth A16 AI+ A3XWHG (15FLIMS1.107) support

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1593,6 +1593,7 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"15F4EMS1.105", // Stealth 16 AI Studio A1VFG
 	"15FKIMS1.106", // Stealth A16 AI+ A3XVFG / A3XVGG
 	"15FKIMS1.109",
+	"15FLIMS1.107", // Stealth A16 AI+ A3XWHG
 	"15K2EMS1.106", // Cyborg 15 AI A1VFK
 	"15M1IMS1.109", // Vector GP68 HX 13V
 	"15M1IMS1.110",


### PR DESCRIPTION
## Summary

Add firmware version `15FLIMS1.107` to `CONF_G2_10` allowlist for MSI Stealth A16 AI+ A3XWHG support.

The EC register layout matches other Stealth A16 AI+ variants already supported (15FKIMS1.xxx series).

## Hardware Info

- **Model:** MSI Stealth A16 AI+ A3XWHG
- **Firmware:** 15FLIMS1.107
- **BIOS:** E15FLAMS.109
- **OS:** NixOS (Linux 6.12.63)

## Tested Features

| Feature | Status |
|---------|--------|
| shift_mode (eco/comfort/turbo) | ✅ |
| fan_mode (auto/silent/advanced) | ✅ |
| cooler_boost | ✅ |
| super_battery | ✅ |
| webcam / webcam_block | ✅ |
| cpu/realtime_temperature | ✅ |
| gpu/realtime_temperature | ✅ |
| cpu/realtime_fan_speed | ✅ |
| gpu/realtime_fan_speed | ✅ |
| Battery charge thresholds | ✅ |

Fixes #533