### PR TITLE
Add support New BIOS version for Raider GE68 HX 13V

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1602,6 +1602,7 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"15M1IMS2.111",
 	"15M1IMS2.112",
 	"15M2IMS1.110", // Raider GE68HX 13V(F/G)
+	"15M2IMS1.114", // New Raider GE68HX bios firmwareversion
 	"15M2IMS1.112", // Vector GP68HX 13VF
 	"15M2IMS1.113",
 	"15M3EMS1.105", // Vector 16 HX AI A2XWHG

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1603,9 +1603,9 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"15M1IMS2.111",
 	"15M1IMS2.112",
 	"15M2IMS1.110", // Raider GE68HX 13V(F/G)
-	"15M2IMS1.114", // New Raider GE68HX bios firmwareversion
 	"15M2IMS1.112", // Vector GP68HX 13VF
 	"15M2IMS1.113",
+	"15M2IMS1.114",
 	"15M3EMS1.105", // Vector 16 HX AI A2XWHG
 	"15M3EMS1.106",
 	"15M3EMS1.107",


### PR DESCRIPTION
close #305  close #384

---

 I have verified and tested the operation of the new BIOS version for the GE68. I have been using it daily for over a month. The version number has been thoroughly checked.