### PR TITLE
Add support for MSI GP75 Leopard 10SEK

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -136,8 +136,9 @@ static const char *ALLOWED_FW_G1_1[] __initconst = {
 	"17F4EMS2.100", // GF75 Thin 9SCSR
 	"17F5EMS1.102", // GF75 Thin 10UEK
 	"17F6EMS1.103", // GF75 Thin 10UC / 10UD
+	"17E7EMS1.103", // GP75 Leopard 10SEK
+	"17E7EMS1.106", // GL75 Leopard 10SFR
 	"17E8EMS1.101", // GL75 Leopard 10SCXR
-        "17E7EMS1.103", // GP75 Leopard 10SEK
 	NULL
 };
 


### PR DESCRIPTION
## Summary
Add firmware version 17E7EMS1.103 to ALLOWED_FW_G1_1 allowlist for MSI GP75 Leopard 10SEK support.

I have tested this extensively with several EC dumps & confirmed it's working as expected.

### Hardware Info
Model: MSI GP75 Leopard 10SEK
BIOS version: E17E7IMS.10C
Firmware version: 17E7EMS1.103
OS: CachyOS


```
00000000  00 80 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000010  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000020  00 00 00 00 00 00 00 00  00 03 00 80 c0 06 5b 0b  |..............[.|
00000030  01 01 01 0d 51 0a 05 00  7a 12 6c 2a ea 01 c7 00  |....Q...z.l*....|
00000040  22 0b 48 00 c2 0c 00 00  14 09 64 2c 3d 0c 0c 30  |".H.......d,=..0|
00000050  00 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  |................|
00000060  00 00 00 00 00 00 00 00  44 00 32 38 3e 46 4b 50  |........D.28>FKP|
00000070  64 50 00 28 32 3c 46 50  5a 00 0a 07 07 09 09 09  |dP.(2<FPZ.......|
00000080  44 00 37 3c 41 46 4b 50  61 3b 00 2d 34 3b 45 4f  |D.7<AFKPa;.-4;EO|
00000090  59 00 0a 07 07 07 07 07  02 16 7d 02 16 66 00 00  |Y.........}..f..|
000000a0  31 37 45 37 45 4d 53 31  2e 31 30 33 30 32 31 38  |17E7EMS1.1030218|
000000b0  32 30 32 30 30 39 3a 33  35 3a 32 32 c4 0c 40 10  |202009:35:22..@.|
000000c0  00 07 23 00 00 9e c0 00  00 1e 00 86 00 bb 14 00  |..#.............|
000000d0  00 00 00 00 70 00 00 00  00 00 00 80 00 00 00 00  |....p...........|
000000e0  e2 02 00 3b 10 00 00 00  00 00 81 00 00 9a 00 d0  |...;............|
000000f0  00 00 c1 83 0d 00 05 80  00 00 00 00 00 00 00 00  |................|
00000100
```

---

close  #580 by adding extra version `17E7EMS1.106`