### PR TITLE
Add 17KKIMS1.115 for MSI Alpha 17 C7V

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1218,6 +1218,7 @@ static const char *ALLOWED_FW_G2_2[] __initconst = {
 	"17KKIMS1.108", // Alpha 17 C7VF / C7VG
 	"17KKIMS1.109",
 	"17KKIMS1.114",
+	"17KKIMS1.115",
 	"17M1EMS1.113", // Stealth GS76 11UG
 	NULL
 };


### PR DESCRIPTION
```
;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
;;                                                                          ;;
;;			MSI BIOS Release Notes     	                    ;;
;;					                                    ;;
;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;           
                     
Model    :   MS-17KK                        
MKT Name :   Alpha 17 C7VG/Alpha 17 C7VF

;****************************************************************************;

;****************************************************************************;

New BIOS     : 	E17KKAMS.123
ROM CheckSum :  0x0F19
Release Date :  2026.1.30

;--------------------------- Description ------------------------------------;

1,Fixed CPU frequency limitation at 0.5 GHz.
2,Update the EC version to 17KKIMS1.115.
```

close #99