### PR TITLE
Add Katana A15 AI B8VG model name for 158NIMS1.505

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1118,7 +1118,7 @@ static const char *ALLOWED_FW_G2_1[] __initconst = {
 	"158NIMS1.10E",
 	"158NIMS1.30C", // Bravo 15 C7VFKP
 	"158NIMS1.502", // Katana A15 AI B8V(F)
-	"158NIMS1.505",
+	"158NIMS1.505", // Katana A15 AI B8VG
 	"158PIMS1.106", // Bravo 15 B7ED
 	"158PIMS1.111",
 	"158PIMS1.112",


### PR DESCRIPTION
close #96

Add model name comment for firmware version `158NIMS1.505` — MSI Katana A15 AI B8VG (MS-158N).

Tested on:
- **Model**: Katana A15 AI B8VG
- **Board**: MS-158N
- **BIOS**: E158NAMS.510
- **EC firmware**: 158NIMS1.505
- **Kernel**: 6.18.7-zen1-1-zen (Arch Linux)
- **Config**: CONF_G2_1 — shift_mode, fan_mode, cooler_boost all working