### PR TITLE
Add EC version 16R8IMS1.117 for MSI GF63 12V(E/F)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1543,6 +1543,7 @@ static const char *ALLOWED_FW_G2_6[] __initconst = {
 	"16R8IMS1.107",
 	"16R8IMS1.108", // Thin GF63 12UCX
 	"16R8IMS1.111", // Thin GF63 12V(E/F)
+	"E16R8IMS.117", // Thin GF63 12V(E/F)
 	"16R8IMS1.117", // Thin GF63 12UC
 	"16R8IMS2.111", // Thin 15 B12UCX / B12VE
 	"16R8IMS2.112",


### PR DESCRIPTION
- Added the new EC version .117 to the config for this model.  ~~Currently testing.~~ TESTED.