### PR TITLE
Updated firmware for MSI Stealth 14 A1VGG

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1469,6 +1469,7 @@ static const char *ALLOWED_FW_G2_5[] __initconst = {
 	"14K1EMS1.108",
 	"14K2EMS1.104", // Stealth 14 AI Studio A1VGG / A1VFG
 	"14K2EMS1.107",
+	"14K2EMS1.108"
 	NULL
 };
 


### PR DESCRIPTION
close #596

---

Just a small update for the MSI Stealth 14 Firmware version that bumped to 108 with latest BIOS update. I observed close to no change on how it worked.