### PR TITLE
msi-ec: fix typo

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1469,7 +1469,7 @@ static const char *ALLOWED_FW_G2_5[] __initconst = {
 	"14K1EMS1.108",
 	"14K2EMS1.104", // Stealth 14 AI Studio A1VGG / A1VFG
 	"14K2EMS1.107",
-	"14K2EMS1.108"
+	"14K2EMS1.108",
 	NULL
 };
 


### PR DESCRIPTION
The latest commit #633 introduces a typo. A comma was missing. Adding the comma fixes the build

---

close #596