### PR TITLE
Added 158NIMS1.506 for Katana B8V(F). Move from G2_1 to G2_10 due to backlight not connected

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1118,8 +1118,6 @@ static const char *ALLOWED_FW_G2_1[] __initconst = {
 	"158NIMS1.10D", // Bravo 15 C7UCX
 	"158NIMS1.10E",
 	"158NIMS1.30C", // Bravo 15 C7VFKP
-	"158NIMS1.502", // Katana A15 AI B8V(F)
-	"158NIMS1.505",
 	"158PIMS1.106", // Bravo 15 B7ED
 	"158PIMS1.111",
 	"158PIMS1.112",
@@ -1626,6 +1624,10 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"1572EMS1.106", // Creator Z16 A12U
 	"1572EMS1.107",
 	"1587EMS1.102", // Katana 15 HX B14WEK
+	"158NIMS1.502", // Katana A15 AI B8V
+	"158NIMS1.505",
+	"158NIMS1.506",
+	"158NIMS1.507",
 	"15F2EMS1.109", // Stealth 16 Studio A13VG
 	"15F4EMS1.105", // Stealth 16 AI Studio A1VFG
 	"15F4EMS1.106",


### PR DESCRIPTION
close #347 (source)
+ G2_1
  + `158NIMS1.507`
close #659
close #667


---

2 things in this merge request:

1. Added a the new EC firmware 158NIMS1.506 for Katana B8V(F).
2. Move the 158NIMS1.5XX for the Katana B8V(F) to G2_10 (from G2_1) since the RGB keyboard backlight is driven by hidraw usb (MS-1565). Same with the other owners of this model/configuration #347 .
 (Is there some other easy automated solution to not have it show up a nonexistent keyboard backlight?) 