### PR TITLE
msi-ec: add support for Creator Z16 A11UE firmware E1571IMS.109

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1577,6 +1577,7 @@ static struct msi_ec_conf CONF_G2_6 __initdata = {
 		.modes = {
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
+			{ SM_SPORT_NAME,   0xc0 },
 			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
@@ -1716,7 +1717,8 @@ static struct msi_ec_conf CONF_G2_10 __initdata = {
 		.modes = {
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 }, // sometimes 0xc0
+			{ SM_SPORT_NAME,   0xc0 },
+			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},


### PR DESCRIPTION
close #603

---

Model: MSI Creator Z16 A11UE (MS-1571)
DMI product name: Creator Z16 A11UE
EC firmware string: E1571IMS.109
EC self-reports as: 1571EMS1.106

Changes:
1. Added E1571IMS.109 to ALLOWED_FW_G2_10 whitelist
2. Added SM_SPORT_NAME (0xc0) to CONF_G2_10 shift_mode mapping,
   removing the stale "sometimes 0xc0" comment on turbo

Tested sysfs entries:
- fw_version: 1571EMS1.106 ✓
- fan_mode: auto ✓
- available_fan_modes: auto, silent, advanced ✓
- cooler_boost: off ✓
- shift_mode: sport ✓
- available_shift_modes: eco, comfort, sport, turbo ✓