### PR TITLE
Fix MSI Katana 17 B11UCX (17L2EMS1.108) configuration grouping

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1144,7 +1144,6 @@ static const char *ALLOWED_FW_G2_1[] __initconst = {
 	"17L1EMS1.107",
 	"17L2EMS1.103", // Katana GF76 11UC / 11UD
 	"17L2EMS1.106",
-	"17L2EMS1.108", // Katana 17 B11UCX
 	"17L3EMS1.106", // Crosshair 17 B12UGZ
 	"17L3EMS1.109", // Katana GF76 12UG
 	"17L4EMS1.112", // Katana GF76 12UC
@@ -1756,6 +1755,74 @@ static struct msi_ec_conf CONF_G2_10 __initdata = {
 	},
 };
 
+static const char *ALLOWED_FW_KATANA_17_B11UCX[] __initconst = {
+	"17L2EMS1.108", // Katana 17 B11UCX
+	NULL
+};
+
+static struct msi_ec_conf CONF_KATANA_17_B11UCX __initdata = {
+	.allowed_fw = ALLOWED_FW_KATANA_17_B11UCX,
+	.charge_control_address = 0xd7,
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4,
+		.invert  = false,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_ECO_NAME,     0xc2 },
+			{ SM_COMFORT_NAME, 0xc1 },
+			{ SM_SPORT_NAME,   0xc0 },
+			{ SM_TURBO_NAME,   0xc4 },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xeb,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address      = 0x68,
+		.rt_fan_speed_address = 0xc9,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0xcb,
+	},
+	.leds = {
+		.micmute_led_address = 0x2c,
+		.mute_led_address    = 0x2d,
+		.bit                 = 1,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = 0x2c,
+		.bl_modes         = { 0x00, 0x08 },
+		.max_mode         = 1,
+		.bl_state_address = 0xd3,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
 /* ^^^^^^^^^^^^^^^^ Gen 2 - WMI2 ^^^^^^^^^^^^^^^^ */
 
 static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
@@ -1783,6 +1850,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF_G2_5,
 	&CONF_G2_6,
 	&CONF_G2_10,
+	&CONF_KATANA_17_B11UCX,
 	NULL
 };
 


### PR DESCRIPTION
close #97

This PR extracts the Katana 17 B11UCX (`17L2EMS1.108`) from the generic `CONF_G2_1` configuration and restores its original dedicated profile.
The configuration for this specific firmware was already added and verified a few years ago in PR https://github.com/BeardOverflow/msi-ec/pull/97. However, later it was incorrectly grouped into `CONF_G2_1`, which broke several features by applying the wrong addresses:

* **Fan speeds:** Broken in the generic profile. Restored to `0xc9` (CPU) and `0xcb` (GPU) with inverted values.

* **Shift Mode:** The `sport` mode became unavailable. Restored address to `0xd2` (supports eco, comfort, sport, turbo).

* **Win/Fn Swap:** The generic profile inverted the logic. Restored to `0xe8` (Bit 4, `invert = false`).

This patch simply returns the addressing and logic for `17L2EMS1.108` back to the working state. 

close #138