### PR TITLE
Add support for GF63 Thin 11UC firmware E16R6IMS.10D

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -585,6 +585,11 @@ static struct msi_ec_conf CONF_G1_6 __initdata = {
 };
 
 static const char *ALLOWED_FW_G1_7[] __initconst = {
+	"16R6EMS1.103", // GF63 Thin 11UC / 11SC
+	"16R6EMS1.104",
+	"16R6EMS1.106",
+	"16R6EMS1.107",
+	"E16R6IMS.10D", // GF63 Thin 11UC - BIOS E16R6IMS.10D
 	"16R1EMS1.105", // GF63 8RC-249
 	"16R3EMS1.100", // GF63 Thin 9SC
 	"16R3EMS1.102",
@@ -1535,6 +1540,11 @@ static struct msi_ec_conf CONF_G2_5 __initdata = {
 };
 
 static const char *ALLOWED_FW_G2_6[] __initconst = {
+	"16R6EMS1.103", // GF63 Thin 11UC / 11SC
+	"16R6EMS1.104",
+	"16R6EMS1.106",
+	"16R6EMS1.107",
+	"E16R6IMS.10D", // GF63 Thin 11UC - BIOS E16R6IMS.10D
 	"16R6EMS1.103", // GF63 Thin 11UC / 11SC
 	"16R6EMS1.104",
 	"16R6EMS1.106",


### PR DESCRIPTION
## Device Information
- **Model:** MSI GF63 Thin 11UC
- **Board name:** MS-16R6
- **EC Firmware version:** E16R6IMS.10D
- **BIOS release date:** 06/23/2022
- **Kernel version:** 6.8.0-107-generic (Ubuntu 24.04)

## Changes
Added `E16R6IMS.10D` to the list of supported firmware versions 
alongside the existing 16R6EMS1 entries for the GF63 Thin 11UC/11SC.

## Testing
Tested and confirmed working:
- [x] Driver loads successfully (msi-ec platform device created)
- [x] Shift mode control
- [x] Fan mode switching
- [x] MControlCenter launches and shows all controls

## Notes
The firmware string `E16R6IMS.10D` differs slightly from the existing 
`16R6EMS1.10x` entries but belongs to the same board (MS-16R6 / GF63 Thin 11UC).

---

close #72