### PR TITLE
update 700

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1032,6 +1032,7 @@ static const char *ALLOWED_FW_G2_0[] __initconst = {
 	"159KIMS1.107", // Prestige A16 AI+ A3HMG
 	"159KIMS1.108", // Summit A16 AI+ A3HMTG
 	"159KIMS1.110",
+	"159KIMS1.111",
 	"15H1IMS1.214", // Modern 15 B13M
 	"15H5EMS1.111", // Modern 15 H AI C1MG
 	NULL
@@ -1153,6 +1154,7 @@ static const char *ALLOWED_FW_G2_1[] __initconst = {
 	"17LNIMS1.10E", // Bravo 17 C7VE
 	"17LNIMS1.505", // Katana A17 AI B8VF
 	"17LNIMS1.506",
+	"17LNIMS1.507",
 	"17M1EMS2.113", // Creator 17 B11UE
 	NULL
 };

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -85,6 +85,7 @@ static struct msi_ec_conf CONF_G1_0 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
 			{ SM_SPORT_NAME,   0xc0 },
@@ -170,10 +171,10 @@ static struct msi_ec_conf CONF_G1_1 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
 			{ SM_SPORT_NAME,   0xc0 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -241,9 +242,9 @@ static struct msi_ec_conf CONF_G1_2 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
-			{ SM_ECO_NAME,     0xc2 }, // super_battery = 0xa5
-			{ SM_COMFORT_NAME, 0xc1 }, // silent: super_battery = 0xa4 / balanced: super_battery = 0xa1
-			{ SM_TURBO_NAME,   0xc4 }, // super_battery = 0xa0
+			{ SM_TURBO_NAME,   0xc4 },
+			{ SM_ECO_NAME,     0xc2 },
+			{ SM_COMFORT_NAME, 0xc1 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -326,10 +327,10 @@ static struct msi_ec_conf CONF_G1_3 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
 			{ SM_SPORT_NAME,   0xc0 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -397,10 +398,10 @@ static struct msi_ec_conf CONF_G1_4 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
 			{ SM_SPORT_NAME,   0xc0 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -474,7 +475,7 @@ static struct msi_ec_conf CONF_G1_5 __initdata = {
 		.modes = {
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc0 },
+			{ SM_SPORT_NAME,   0xc0 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -552,7 +553,7 @@ static struct msi_ec_conf CONF_G1_6 __initdata = {
 		.modes = {
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc0 },
+			{ SM_SPORT_NAME,   0xc0 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -631,10 +632,10 @@ static struct msi_ec_conf CONF_G1_7 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
 			{ SM_SPORT_NAME,   0xc0 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -702,9 +703,9 @@ static struct msi_ec_conf CONF_G1_8 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 }, // Performance
 			{ SM_ECO_NAME,     0xc2 }, // Super Battery
 			{ SM_COMFORT_NAME, 0xc1 }, // Silent / Balanced / AI
-			{ SM_TURBO_NAME,   0xc4 }, // Performance
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -775,10 +776,10 @@ static struct msi_ec_conf CONF_G1_9 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 }, // extreme
 			{ SM_ECO_NAME,     0xc2 }, // super battery
 			{ SM_COMFORT_NAME, 0xc1 }, // balanced
 			{ SM_SPORT_NAME,   0xc0 }, // sport
-			{ SM_TURBO_NAME,   0xc4 }, // extreme
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -918,9 +919,9 @@ static struct msi_ec_conf CONF_G1_11 __initdata = {
 	.shift_mode = {
 		.address = 0xf2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -989,7 +990,7 @@ static struct msi_ec_conf CONF_G1_13 __initdata = {
 		.modes = {
 			{ SM_ECO_NAME,     0xc2 }, // Super Battery
 			{ SM_COMFORT_NAME, 0xc1 }, // Balanced + Silent
-			{ SM_TURBO_NAME,   0xc0 },
+			{ SM_SPORT_NAME,   0xc0 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1073,9 +1074,9 @@ static struct msi_ec_conf CONF_G2_0 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1197,9 +1198,9 @@ static struct msi_ec_conf CONF_G2_1 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1289,9 +1290,9 @@ static struct msi_ec_conf CONF_G2_2 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1388,9 +1389,9 @@ static struct msi_ec_conf CONF_G2_3 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1458,9 +1459,9 @@ static struct msi_ec_conf CONF_G2_4 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1534,9 +1535,9 @@ static struct msi_ec_conf CONF_G2_5 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1618,9 +1619,9 @@ static struct msi_ec_conf CONF_G2_6 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
 	},
@@ -1776,9 +1777,9 @@ static struct msi_ec_conf CONF_G2_10 __initdata = {
 	.shift_mode = {
 		.address = 0xd2,
 		.modes = {
+			{ SM_TURBO_NAME,   0xc4 }, // sometimes 0xc0
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_TURBO_NAME,   0xc4 }, // sometimes 0xc0
 			MSI_EC_MODE_NULL
 		},
 	},

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -60,7 +60,8 @@ static const char *ALLOWED_FW_G1_0[] __initconst = {
 	"14C1EMS1.012", // Prestige 14 A10SC
 	"14C1EMS1.101",
 	"14C1EMS1.102",
-	"16S3EMS1.103", // Prestige 15 A10SC
+	"16S3EMS1.102", // Prestige 15 A10SC
+	"16S3EMS1.103",
 	NULL
 };
 
@@ -745,7 +746,8 @@ static const char *ALLOWED_FW_G1_9[] __initconst = {
 	"17G1EMS1.100", // GS75 Stealth 8SF
 	"17G1EMS1.102", // GS75 Stealth 9SF
 	"17G1EMS1.107",
-	"17G3EMS1.113", // GS75 Stealth 10SF
+	"17G3EMS1.110", // GS75 Stealth 10SF
+	"17G3EMS1.113",
 	"17G3EMS1.115",
 	NULL
 };
@@ -1037,6 +1039,7 @@ static const char *ALLOWED_FW_G2_0[] __initconst = {
 	"159KIMS1.107", // Prestige A16 AI+ A3HMG
 	"159KIMS1.108", // Summit A16 AI+ A3HMTG
 	"159KIMS1.110",
+	"159KIMS1.111",
 	"15H1IMS1.205", // Modern 15 B12MO
 	"15H1IMS1.214", // Modern 15 B13M
 	"15H4IMS1.107", // Modern 15 H B13M
@@ -1109,7 +1112,7 @@ static struct msi_ec_conf CONF_G2_0 __initdata = {
 };
 
 static const char *ALLOWED_FW_G2_1[] __initconst = {
-	"14C4EMS1.120", // Prestige 14 A11SCX
+	"14C4EMS1.120", // Prestige 14 A11SCX / A11SCS
 	"14C6EMS1.109", // Prestige 14 Evo A12M
 	"1581EMS1.107", // Katana GF66 11UE / 11UG
 	"1582EMS1.105", // Pulse GL66 11UDK
@@ -1159,11 +1162,13 @@ static const char *ALLOWED_FW_G2_1[] __initconst = {
 	"17L2EMS1.106",
 	"17L2EMS1.108", // Katana 17 B11UCX
 	"17L3EMS1.106", // Crosshair 17 B12UGZ
-	"17L3EMS1.109", // Katana GF76 12UG
+	"17L3EMS1.109", // Katana GF76 12UG / Pulse GL76 12U
 	"17L4EMS1.112", // Katana GF76 12UC
 	"17LNIMS1.10E", // Bravo 17 C7VE
-	"17LNIMS1.505", // Katana A17 AI B8VF
+	"17LNIMS1.502", // Katana A17 AI B8VF
+	"17LNIMS1.505",
 	"17LNIMS1.506",
+	"17LNIMS1.507",
 	"17M1EMS2.113", // Creator 17 B11UE
 	NULL
 };
@@ -1582,6 +1587,7 @@ static const char *ALLOWED_FW_G2_6[] __initconst = {
 	"16RKIMS1.110", // Thin A15 B7VF
 	"16RKIMS1.111",
 	"16RKIMS2.108",
+	"16RKIMS2.111",
 	NULL
 };
 
@@ -1655,7 +1661,8 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"1571EMS1.106", // Creator Z16 A11UE
 	"1572EMS1.106", // Creator Z16 A12U
 	"1572EMS1.107",
-	"1587EMS1.102", // Katana 15 HX B14WEK
+	"1587EMS1.102", // Katana 15 HX B14WEK / B14WGK
+	"1587EMS1.104",
 	"1587EMS1.106",
 	"158NIMS1.502", // Katana A15 AI B8V
 	"158NIMS1.505",
@@ -1663,7 +1670,8 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"158NIMS1.507",
 	"15B1EMS1.103", // Stealth 15M B12UE
 	"15F2EMS1.109", // Stealth 16 Studio A13VG
-	"15F3EMS1.105", // Stealth 16 AI Studio A1VHG
+	"15F3EMS1.104", // Stealth 16 AI Studio A1VHG
+	"15F3EMS1.105",
 	"15F4EMS1.105", // Stealth 16 AI Studio A1VFG
 	"15F4EMS1.106",
 	"15F4EMS1.107",

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -370,6 +370,7 @@ static struct msi_ec_conf CONF_G1_3 __initdata = {
 };
 
 static const char *ALLOWED_FW_G1_4[] __initconst = {
+	"16JFEMS1.105", // GV62 8RD
 	"17FKEMS1.108", // Bravo 17 A4DDR / A4DDK
 	"17FKEMS1.109",
 	"17FKEMS1.10A",
@@ -742,6 +743,7 @@ static struct msi_ec_conf CONF_G1_8 __initdata = {
 };
 
 static const char *ALLOWED_FW_G1_9[] __initconst = {
+	"17E9EMS1.105", // GE75 Raider 10 SF / SFS / SGS
 	"17G1EMS2.106", // P75  CREATOR 9SG
 	"17G1EMS1.100", // GS75 Stealth 8SF
 	"17G1EMS1.102", // GS75 Stealth 9SF
@@ -749,6 +751,7 @@ static const char *ALLOWED_FW_G1_9[] __initconst = {
 	"17G3EMS1.110", // GS75 Stealth 10SF
 	"17G3EMS1.113",
 	"17G3EMS1.115",
+	"17H1EMS1.103", // GT76 Titan DT 9 SF / SFS / SG / SGS
 	NULL
 };
 
@@ -817,6 +820,7 @@ static struct msi_ec_conf CONF_G1_9 __initdata = {
 static const char *ALLOWED_FW_G1_10[] __initconst = {
 	"16P5EMS1.103", // GE63 Raider 8RE
 	"1782EMS1.109", // GT72 6QE Dominator Pro
+	"1799EMS1.112", // GP72 7REX Leopard Pro
 	NULL
 };
 
@@ -1246,6 +1250,7 @@ static const char *ALLOWED_FW_G2_2[] __initconst = {
 	"16V4EMS1.114", // GS66 Stealth 11UE / 11UG
 	"16V4EMS1.115",
 	"16V4EMS1.116",
+	"16V4EMS2.106", // Creator 15 A11UE
 	"16V5EMS1.107", // Stealth GS66 12UE / 12UGS
 	"16V5EMS1.108",
 	"17K3EMS1.112", // GE76 Raider 11U / 11UH
@@ -1355,9 +1360,11 @@ static const char *ALLOWED_FW_G2_3[] __initconst = {
 	"13Q3EMS1.111", // Prestige 13 AI+ Evo A2VMG
 	"14Q2EMS1.301", // Venture 14 AI A2HMG
 	"14QKIMS1.108", // Venture A14 AI+ A3HMG
+	"14T2EMS1.110", // Prestige 14 Flip AI+ D3MTG
 	"15A1EMS1.105", // Prestige 16 AI Evo B1MG
 	"15A1EMS1.109", // Prestige 16 AI Evo B1MG (.109 EC rev)
 	"15A3EMS1.104", // Prestige 16 AI+ Evo B2VMG
+	"15QKIMS1.506", // Venture A15 AI A2HMG / A2HMTG
 	NULL
 };
 
@@ -1681,6 +1688,7 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"15FKIMS1.110", // Stealth A16 AI+ A3XVGG
 	"15FLIMS1.107", // Stealth A16 AI+ A3XWHG
 	"15FMIBA1.102", // Stealth A16 Mercedes AMG AI+ A3XWGG
+	"15G2EWS1.107", // CreatorPro Z16HXStudio B13VJTO / B13VKTO
 	"15K2EMS1.106", // Cyborg 15 AI A1VFK
 	"15K2EMS1.109",
 	"15M1IMS1.109", // Vector GP68 HX 13V


### PR DESCRIPTION
```
git clone -b update https://github.com/glpnk/msi-ec.git
cd msi-ec
sudo make dkms-uninstall
sudo make dkms-install
```

---

`CONF_G1_0` add `0xC4` (turbo) shift mode

sorted and cleaned up shifts. Wrong `0xC0` `turbo` renamed to correct `sport`

---

Add:

+ G1_4
  + `16JFEMS1.105` - GV62 8RD
closes #722

+ G1_9
  + `17E9EMS1.105` - GE75 Raider 10 SF / SFS / SGS
close #751
  + `17H1EMS1.103` - GT76 Titan DT 9 SF / SFS / SG / SGS
close #724

+ G1_10 (like g1_9 but w/o battery control)
  + `1799EMS1.112` - GP72 7REX Leopard Pro
close #755


+ G2_2
  + `16V4EMS1.1` Creator 15 A11UE
close #745

+ G2_3
  + `15QKIMS1.506` - Venture A15 AI A2HMG / A2HMTG
close #766
  + `14T2EMS1.110` - Prestige 14 Flip AI+ D3MTG
close #756

+ G2_10
  + `15G2EWS1.107` - CreatorPro Z16HXStudio B13VKTO / B13VJTO
close #770

---

Update:

+ G1_0
  + `16S3EMS1.102`
close #760

+ G1_9
  + `17G3EMS1.110`
close #728


+ G2_0
  + `159KIMS1.111`
close #524
close #707

+ G2_1
  + `17LNIMS1.507`
close #704
close #776

+ G2_6
  + `16RKIMS2.111`
close #713

+ G2_10
  + `1587EMS1.104`
close #769
  + `15F3EMS1.104`
close #701

---

Template

```
Add:

+ Gx_y
  + `nnnnbMSx.yzz` - name
close #

---

Update:

+ Gx_y
  + `nnnnbMSx.yzz`
close #
```