### PR TITLE
feat: Add support for GE76 Raider 10UG (WMI gen 1)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -299,6 +299,7 @@ static const char *ALLOWED_FW_G1_3[] __initconst = {
 	"16V1EMS1.116",
 	"16V1EMS1.118", // GS66 Stealth 10SE
 	"16V3EMS1.106", // GS66 Stealth 10UE
+	"17K2EMS1.104", // GE76 Raider 10UG
 	NULL
 };
 


### PR DESCRIPTION
Everything else works correctly, but both fan-mode and shift-mode have invalid values after booting to Linux. Setting them to correct values does work, but they get reset again to invalid values after reboot.

---

close #608 