### PR TITLE
feat: add support for GL65 9SD

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -127,6 +127,7 @@ static struct msi_ec_conf CONF_G1_0 __initdata = {
 };
 
 static const char *ALLOWED_FW_G1_1[] __initconst = {
+	"16U5EMS1.100", // GL65 9SD
 	"16U7EMS1.105", // GP65 / GL65 Leopard 10S
 	"16U7EMS1.106",
 	"16U7EMS1.504", // GL65 Leopard 9SD


### PR DESCRIPTION
Model Name: GL65 9SD (not Leopard)
EC Version: 16U5EMS1.100

Tested on 6.18.26-2 (Fedora 37)

close #680 close #689 