### PR TITLE
Add support for Raider 18 HX AI A2XWJG (1824EMS1.108)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1714,6 +1714,7 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"1822EMS1.114",
 	"1822EMS1.115",
 	"1824EMS1.107", // Titan 18 HX Dragon Edition
+	"1824EMS1.108", // Raider 18 HX AI A2XWJG (MS-1824)
 	"182LIMS1.108", // Vector A18 HX A9WHG
 	"182LIMS1.111", // New ec version for Vector A18 HX A9WHG
 	"182KIMS1.113", // Raider A18 HX A7VIG


### PR DESCRIPTION
## Device
- **Model:** MSI Raider 18 HX AI A2XWJG
- **Board:** MS-1824
- **EC firmware:** \`1824EMS1.108\`
- **Kernel:** 6.17.0-23-generic (Ubuntu 24.04)

## Change
One-line addition to \`ALLOWED_FW_G2_10[]\` (same group as the existing \`1824EMS1.107\` Titan 18 HX Dragon Edition, which shares the same EC layout).

## Tested
All sysfs attributes verified functional after loading the driver:

| Attribute | Result |
|---|---|
| \`fan_mode\` (auto / silent / advanced) | ✅ all switch & read back |
| \`shift_mode\` (eco / comfort / turbo) | ✅ all switch & read back |
| \`cooler_boost\` on/off | ✅ |
| \`super_battery\` on/off | ✅ |
| \`webcam\` / \`webcam_block\` | ✅ |
| \`fn_key\` / \`win_key\` swap | ✅ |
| \`charge_control_{start,end}_threshold\` | ✅ (50/60% honored) |
| \`cpu/realtime_temperature\`, \`cpu/realtime_fan_speed\` | ✅ |
| \`gpu/realtime_temperature\`, \`gpu/realtime_fan_speed\` | ✅ |

No kernel warnings or errors during \`module_init\` or any of the toggle tests. Battery hook registers cleanly via ACPI.

---

close #419 