### PR TITLE
feat: Add support for Prestige 16 Flip AI+ C3MTG (2622EMS1.112)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1366,7 +1366,7 @@ static const char *ALLOWED_FW_G2_3[] __initconst = {
 	"15A1EMS1.109", // Prestige 16 AI Evo B1MG (.109 EC rev)
 	"15A3EMS1.104", // Prestige 16 AI+ Evo B2VMG
 	"15QKIMS1.506", // Venture A15 AI A2HMG / A2HMTG
-	"2622EMS1.111", // Prestige 16 Flip AI+ C3MTG
+	"2622EMS1.112", // Prestige 16 Flip AI+ C3MTG
 	NULL
 };
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1387,7 +1387,7 @@ static struct msi_ec_conf CONF_G2_3 __initdata = {
 		.address = 0x98,
 		.bit     = 7,
 	},
-	.shift_mode = {
+	.shift_mode = {          // 2622 has a new shift mode 0xc5 (super power mode)
 		.address = 0xd2,
 		.modes = {
 			{ SM_TURBO_NAME,   0xc4 },

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1366,6 +1366,7 @@ static const char *ALLOWED_FW_G2_3[] __initconst = {
 	"15A1EMS1.109", // Prestige 16 AI Evo B1MG (.109 EC rev)
 	"15A3EMS1.104", // Prestige 16 AI+ Evo B2VMG
 	"15QKIMS1.506", // Venture A15 AI A2HMG / A2HMTG
+	"2622EMS1.111", // Prestige 16 Flip AI+ C3MTG
 	NULL
 };
 


### PR DESCRIPTION
This probably a new known firmware format, so I add a brand new configuration. There are two main keys different

1. It has a new shift mode called "Performance Enhancement Mode", which set `0xD2` with `C5`
    - I set this value to the `turbo` mode

<img width="2880" height="1800" alt="new_shift_mode" src="https://github.com/user-attachments/assets/f4b906fb-f983-4769-999d-53261163156d" />

2. The mute LED is now set the `0x2D` with `2C` or `2E` (On / Off). But I'm not sure the current code can handle this situation, so l left it with unsupported.

https://github.com/user-attachments/assets/6e12125a-2680-4248-914e-37482c58121d

The full information see the issue close #733 