### PR TITLE
Add support for MSI Stealth 15M B12UE

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1634,6 +1634,7 @@ static struct msi_ec_conf CONF_G2_6 __initdata = {
 static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"1562EMS1.117", // Stealth 15M A11SEK
 	"1563EMS1.106", // Stealth 15M A11UEK
+	"15B1EMS1.103", // Stealth 15M B12UE
 	"1563EMS1.111",
 	"1563EMS1.115",
 	"1571EMS1.106", // Creator Z16 A11UE

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1634,7 +1634,6 @@ static struct msi_ec_conf CONF_G2_6 __initdata = {
 static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"1562EMS1.117", // Stealth 15M A11SEK
 	"1563EMS1.106", // Stealth 15M A11UEK
-	"15B1EMS1.103", // Stealth 15M B12UE
 	"1563EMS1.111",
 	"1563EMS1.115",
 	"1571EMS1.106", // Creator Z16 A11UE
@@ -1646,6 +1645,7 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"158NIMS1.505",
 	"158NIMS1.506",
 	"158NIMS1.507",
+	"15B1EMS1.103", // Stealth 15M B12UE
 	"15F2EMS1.109", // Stealth 16 Studio A13VG
 	"15F3EMS1.105", // Stealth 16 AI Studio A1VHG
 	"15F4EMS1.105", // Stealth 16 AI Studio A1VFG


### PR DESCRIPTION
Added 15B1EMS1.103 to ALLOWED_FW_G2_10[]

Fan control, temperature sensors, performance modes, advanced fan curves, and Cooler Boost all tested on Ubuntu 26.04 LTS with MControlCenter, everything seems functional.

close #420