### PR TITLE
Support Modern 15 B12MO and add sysfs_notify on shift_mode

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1032,6 +1032,7 @@ static const char *ALLOWED_FW_G2_0[] __initconst = {
 	"159KIMS1.107", // Prestige A16 AI+ A3HMG
 	"159KIMS1.108", // Summit A16 AI+ A3HMTG
 	"159KIMS1.110",
+	"15H1IMS1.205", // Modern 15 B12MO
 	"15H1IMS1.214", // Modern 15 B13M
 	"15H5EMS1.111", // Modern 15 H AI C1MG
 	NULL
@@ -1059,6 +1060,7 @@ static struct msi_ec_conf CONF_G2_0 __initdata = {
 		.modes = {
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
+			{ SM_COMFORT_NAME, 0x81 },
 			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
@@ -2334,6 +2336,7 @@ static ssize_t shift_mode_store(struct device *dev,
 			if (result < 0)
 				return result;
 
+			sysfs_notify(&dev->kobj, NULL, "shift_mode");
 			return count;
 		}
 	}

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1060,7 +1060,6 @@ static struct msi_ec_conf CONF_G2_0 __initdata = {
 		.modes = {
 			{ SM_ECO_NAME,     0xc2 },
 			{ SM_COMFORT_NAME, 0xc1 },
-			{ SM_COMFORT_NAME, 0x81 },
 			{ SM_TURBO_NAME,   0xc4 },
 			MSI_EC_MODE_NULL
 		},
@@ -2336,7 +2335,6 @@ static ssize_t shift_mode_store(struct device *dev,
 			if (result < 0)
 				return result;
 
-			sysfs_notify(&dev->kobj, NULL, "shift_mode");
 			return count;
 		}
 	}


### PR DESCRIPTION
This PR adds support for MSI Modern 15 B12MO (firmware 15H1IMS1.205), maps its boot default EC value 0x81 to comfort mode, and calls sysfs_notify() inside shift_mode_store() so userspace daemons can monitor shift mode changes in real-time.

---

close #52