### PR TITLE
Add support for GL63 8RC (16P6EMS1.104)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -811,6 +811,7 @@ static struct msi_ec_conf CONF_G1_9 __initdata = {
 
 static const char *ALLOWED_FW_G1_10[] __initconst = {
 	"16P5EMS1.103", // GE63 Raider 8RE
+	"16P6EMS1.104", // GL63 8RC
 	"1782EMS1.109", // GT72 6QE Dominator Pro
 	NULL
 };


### PR DESCRIPTION
Adds support for MSI GL63 8RC laptop with EC firmware `16P6EMS1.104`.

The EC memory layout matches the existing **CONF_G1_10** configuration (GE63 Raider 8RE), so the firmware was simply added to `ALLOWED_FW_G1_10`.

Closes #757
close #344 
close #557