### PR TITLE
Add firmware 15A1EMS1.109 for Prestige 16 AI Evo B1MG

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1340,6 +1340,7 @@ static const char *ALLOWED_FW_G2_3[] __initconst = {
 	"13Q3EMS1.111", // Prestige 13 AI+ Evo A2VMG
 	"14QKIMS1.108", // Venture A14 AI+ A3HMG
 	"15A1EMS1.105", // Prestige 16 AI Evo B1MG
+	"15A1EMS1.109", // Prestige 16 AI Evo B1MG (.109 EC rev)
 	"15A3EMS1.104", // Prestige 16 AI+ Evo B2VMG
 	NULL
 };


### PR DESCRIPTION
AI disclaimer: every thing below (not this text) was written by Claude 4.8.

## Summary

The **Prestige 16 AI Evo B1MG** also ships with EC firmware `15A1EMS1.109` (BIOS `E15A1IMS.10A`), a minor revision of the already-supported `15A1EMS1.105`. It works with the same `CONF`, so this adds it to `ALLOWED_FW_G2_3`.

```diff
 	"15A1EMS1.105", // Prestige 16 AI Evo B1MG
+	"15A1EMS1.109", // Prestige 16 AI Evo B1MG (.109 EC rev)
```

## Testing

- **Device:** MSI Prestige 16 AI Evo B1MG
- **EC firmware:** `15A1EMS1.109`
- **OS / kernel:** Ubuntu 25.10, kernel `6.17.0-35-generic`
- **Verified working:** charge control — `charge_control_end_threshold` and `charge_control_start_threshold` read and write correctly via the battery hook (`ACPI: battery: new hook: msi-ec`).
- I also verified keyboard backlight, it works!

Other features (fan/cooler boost) were not tested.

close #623