### PR TITLE
Add support for Stealth 16 AI+ B3WH (2631EMS1.110)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1658,6 +1658,7 @@ static const char *ALLOWED_FW_G2_10[] __initconst = {
 	"15FKIMS1.110", // Stealth A16 AI+ A3XVGG
 	"15FLIMS1.107", // Stealth A16 AI+ A3XWHG
 	"15FMIBA1.102", // Stealth A16 Mercedes AMG AI+ A3XWGG
+	"2631EMS1.110", // Stealth 16 AI+ B3WH
 	"15K2EMS1.106", // Cyborg 15 AI A1VFK
 	"15K2EMS1.109",
 	"15M1IMS1.109", // Vector GP68 HX 13V


### PR DESCRIPTION
closes #685 