### PR TITLE
Added support for Creator 15 A10SFS

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -952,8 +952,8 @@ static struct msi_ec_conf CONF_G1_11 __initdata = {
 
 static const char *ALLOWED_FW_G1_13[] __initconst = {
 	"16V2EMS1.104", // Creator 15 A10SD
-	"16V2EMS1.106", // Creator 15 A10SET
 	"16V2EMS1.105", // Creator 15 A10SFS
+	"16V2EMS1.106", // Creator 15 A10SET
 	NULL
 };
 

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -953,6 +953,7 @@ static struct msi_ec_conf CONF_G1_11 __initdata = {
 static const char *ALLOWED_FW_G1_13[] __initconst = {
 	"16V2EMS1.104", // Creator 15 A10SD
 	"16V2EMS1.106", // Creator 15 A10SET
+	"16V2EMS1.105", // Creator 15 A10SFS
 	NULL
 };
 


### PR DESCRIPTION
Added EC firmware version 16V2EMS1.105 to ALLOWED_FW_G1_13 for the MSI Creator 15 A10SFS

close #395