### PR TITLE
Add support for GS66 Stealth 10SGS (16V1EMS1.111)

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -295,6 +295,7 @@ static const char *ALLOWED_FW_G1_3[] __initconst = {
 	"16Q4EMS1.109",
 	"16Q4EMS1.110",
 	"16V1EMS1.109", // GS66 Stealth 10SFS
+	"16V1EMS1.111", // GS66 Stealth 10SGS
 	"16V1EMS1.112",
 	"16V1EMS1.116",
 	"16V1EMS1.118", // GS66 Stealth 10SE


### PR DESCRIPTION
# Add support for GS66 Stealth 10SGS (EC firmware 16V1EMS1.111)

This adds `16V1EMS1.111` to the `CONF_G1_3` supported firmware list.

The firmware appears to use the same EC layout as the already supported GS66 firmware versions (`16V1EMS1.109`, `.112`, `.116`, `.118`).

## Platform information

- Product: GS66 Stealth 10SGS
- Board: MS-16V1
- BIOS: E16V1IMS.112
- EC firmware: 16V1EMS1.111