### PR TITLE
msi-ec: add firmware 15H4IMS1.107/.108/.117 for Modern 15 H B13M

### DIFF
--- a/msi-ec.c
+++ b/msi-ec.c
@@ -1033,6 +1033,9 @@ static const char *ALLOWED_FW_G2_0[] __initconst = {
 	"159KIMS1.108", // Summit A16 AI+ A3HMTG
 	"159KIMS1.110",
 	"15H1IMS1.214", // Modern 15 B13M
+	"15H4IMS1.107", // Modern 15 H B13M
+	"15H4IMS1.108",
+	"15H4IMS1.117",
 	"15H5EMS1.111", // Modern 15 H AI C1MG
 	NULL
 };


### PR DESCRIPTION
## Summary
Add support for **Modern 15 H B13M** by registering EC firmware versions `15H4IMS1.107`, `15H4IMS1.108`, and `15H4IMS1.117` in `ALLOWED_FW_G2_0`.

This model uses the same EC layout as the Modern 15 B13M (`15H1IMS1`) / Modern 15 H AI C1MG (`15H5EMS1`) config (`CONF_G2_0`), as noted in discussion #277 for issue #488.

## Testing

- **Device:** MSI Modern 15 H B13M (MS-15H4)
- **EC firmware:** `15H4IMS1.107` (also verified against dumps for `.108` and `.117` from #488)
- **OS / kernel:** Ubuntu 24.04, kernel `6.14.0-37-generic`
- **Verified working:**
  - Module loads (`msi_ec: module_init`, `ACPI: battery: new hook: msi-ec`)
  - `fw_version` → `15H4IMS1.107`
  - `shift_mode` → `comfort`
  - `fan_mode` → `auto`
  - `cooler_boost` → `off`
  - CPU temp / fan speed via sysfs
  - Charge control thresholds (`start=70`, `end=80`)
  - Keyboard backlight + mute/micmute LED class devices registered
  - WebCam toggle
  - Fn/Meta

Closes #488