### PR TITLE
Add support for rear 'STEALTH' leds on 14K1EMS1 and 14K2EMS1 models

### DIFF
--- a/ec_memory_configuration.h
+++ b/ec_memory_configuration.h
@@ -69,6 +69,8 @@ struct msi_ec_led_conf {
 	int micmute_led_address;
 	int mute_led_address;
 	int bit;
+	int stealth_led_address;
+	int stealth_led_bit;
 };
 
 #define MSI_EC_KBD_BL_STATE_MASK 0x3

--- a/msi-ec.c
+++ b/msi-ec.c
@@ -117,6 +117,8 @@ static struct msi_ec_conf CONF_G1_0 __initdata = {
 		.micmute_led_address = 0x2b,
 		.mute_led_address    = 0x2c,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = 0x2c,
@@ -202,6 +204,8 @@ static struct msi_ec_conf CONF_G1_1 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = 0x2c,
@@ -273,6 +277,8 @@ static struct msi_ec_conf CONF_G1_2 __initdata = {
 		.micmute_led_address = 0x2b,
 		.mute_led_address    = 0x2c,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -359,6 +365,8 @@ static struct msi_ec_conf CONF_G1_3 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -430,6 +438,8 @@ static struct msi_ec_conf CONF_G1_4 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = 0x2c,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNKNOWN,
@@ -504,6 +514,8 @@ static struct msi_ec_conf CONF_G1_5 __initdata = {
 		.micmute_led_address = 0x2b,
 		.mute_led_address    = 0x2c,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -582,6 +594,8 @@ static struct msi_ec_conf CONF_G1_6 __initdata = {
 		.micmute_led_address = 0x2b,
 		.mute_led_address    = 0x2c,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNKNOWN,
@@ -665,6 +679,8 @@ static struct msi_ec_conf CONF_G1_7 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -732,6 +748,8 @@ static struct msi_ec_conf CONF_G1_8 __initdata = {
 	.leds = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -807,6 +825,8 @@ static struct msi_ec_conf CONF_G1_9 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -875,6 +895,8 @@ static struct msi_ec_conf CONF_G1_10 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -950,6 +972,8 @@ static struct msi_ec_conf CONF_G1_11 __initdata = {
 		.micmute_led_address = 0x2b,
 		.mute_led_address    = 0x2c,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNKNOWN,
@@ -1019,6 +1043,8 @@ static struct msi_ec_conf CONF_G1_13 __initdata = {
 		.micmute_led_address = 0x2b,
 		.mute_led_address    = 0x2c,
 		.bit                 = 2,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -1105,6 +1131,8 @@ static struct msi_ec_conf CONF_G2_0 __initdata = {
 		.micmute_led_address = 0x2c,
 		.mute_led_address    = 0x2d,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = 0x2c,
@@ -1229,6 +1257,8 @@ static struct msi_ec_conf CONF_G2_1 __initdata = {
 		.micmute_led_address = 0x2c,
 		.mute_led_address    = 0x2d,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = 0x2c,
@@ -1321,6 +1351,8 @@ static struct msi_ec_conf CONF_G2_2 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -1420,6 +1452,8 @@ static struct msi_ec_conf CONF_G2_3 __initdata = {
 		.micmute_led_address = 0x2c, // not present on `14F1`
 		.mute_led_address    = 0x2d, // not present on `14L1`, `14N1`, `14QK`. May require udev rule to have ALSA drive LED state on 13P5.
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = 0x2c,
@@ -1490,6 +1524,8 @@ static struct msi_ec_conf CONF_G2_4 __initdata = {
 		.micmute_led_address = 0x2c,
 		.mute_led_address    = 0x2d,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = 0x2c,
@@ -1504,7 +1540,6 @@ static struct msi_ec_conf CONF_G2_4 __initdata = {
 static const char *ALLOWED_FW_G2_5[] __initconst = {
 	"14K1EMS1.103", // Stealth 14 Studio A13VF
 	"14K1EMS1.107",
-	"14K1EMS1.108",
 	"14K2EMS1.104", // Stealth 14 AI Studio A1VGG / A1VFG
 	"14K2EMS1.107",
 	"14K2EMS1.108",
@@ -1566,6 +1601,8 @@ static struct msi_ec_conf CONF_G2_5 __initdata = {
 		.micmute_led_address = 0x2c,
 		.mute_led_address    = 0x2d,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -1650,6 +1687,8 @@ static struct msi_ec_conf CONF_G2_6 __initdata = {
 		.micmute_led_address = MSI_EC_ADDR_UNSUPP,
 		.mute_led_address    = MSI_EC_ADDR_UNSUPP,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -1809,6 +1848,78 @@ static struct msi_ec_conf CONF_G2_10 __initdata = {
 		.micmute_led_address = 0x2c,
 		.mute_led_address    = 0x2d,
 		.bit                 = 1,
+		.stealth_led_address    = MSI_EC_ADDR_UNSUPP,
+		.stealth_led_bit        = 4,
+	},
+	.kbd_bl = {
+		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
+		.bl_modes         = { 0x00, 0x08 },
+		.max_mode         = 1,
+		.bl_state_address = MSI_EC_ADDR_UNSUPP,
+		.state_base_value = 0x80,
+		.max_state        = 3,
+	},
+};
+
+
+static const char *ALLOWED_FW_G2_11[] __initconst = {
+	"14K1EMS1.108", // Stealth 14 Studio A13VF
+	NULL
+};
+
+static struct msi_ec_conf CONF_G2_11 __initdata = {
+	.allowed_fw = ALLOWED_FW_G2_11, // new
+	.charge_control_address = 0xd7,
+	.webcam = {
+		.address       = 0x2e,
+		.block_address = 0x2f,
+		.bit           = 1,
+	},
+	.fn_win_swap = {
+		.address = 0xe8,
+		.bit     = 4,
+		.invert  = false,
+	},
+	.cooler_boost = {
+		.address = 0x98,
+		.bit     = 7,
+	},
+	.shift_mode = {
+		.address = 0xd2,
+		.modes = {
+			{ SM_TURBO_NAME,   0xc4 },
+			{ SM_ECO_NAME,     0xc2 },
+			{ SM_COMFORT_NAME, 0xc1 },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.super_battery = {
+		.address = 0xeb,
+		.mask    = 0x0f,
+	},
+	.fan_mode = {
+		.address = 0xd4,
+		.modes = {
+			{ FM_AUTO_NAME,     0x0d },
+			{ FM_SILENT_NAME,   0x1d },
+			{ FM_ADVANCED_NAME, 0x8d },
+			MSI_EC_MODE_NULL
+		},
+	},
+	.cpu = {
+		.rt_temp_address      = 0x68,
+		.rt_fan_speed_address = 0x71,
+	},
+	.gpu = {
+		.rt_temp_address      = 0x80,
+		.rt_fan_speed_address = 0x89,
+	},
+	.leds = {
+		.micmute_led_address = 0x2c,
+		.mute_led_address    = 0x2d,
+		.bit                 = 1,
+		.stealth_led_address    = 0x2c,
+		.stealth_led_bit        = 4,
 	},
 	.kbd_bl = {
 		.bl_mode_address  = MSI_EC_ADDR_UNSUPP,
@@ -1847,6 +1958,7 @@ static struct msi_ec_conf *CONFIGURATIONS[] __initdata = {
 	&CONF_G2_5,
 	&CONF_G2_6,
 	&CONF_G2_10,
+	&CONF_G2_11,
 	NULL
 };
 
@@ -2819,6 +2931,19 @@ static int mute_led_sysfs_set(struct led_classdev *led_cdev,
 	return 0;
 }
 
+static int stealth_led_sysfs_set(struct led_classdev *led_cdev,
+			      enum led_brightness brightness)
+{
+	int result;
+
+	result = ec_set_bit(conf.leds.stealth_led_address, conf.leds.stealth_led_bit, brightness);
+
+	if (result < 0)
+		return result;
+
+	return 0;
+}
+
 static enum led_brightness kbd_bl_sysfs_get(struct led_classdev *led_cdev)
 {
 	u8 rdata;
@@ -2855,6 +2980,12 @@ static struct led_classdev mute_led_cdev = {
 	.max_brightness = 1,
 	.brightness_set_blocking = &mute_led_sysfs_set,
 	.default_trigger = "audio-mute",
+};
+
+static struct led_classdev stealth_led_cdev = {
+	.name = "platform::stealth",
+	.max_brightness = 1,
+	.brightness_set_blocking = &stealth_led_sysfs_set,
 };
 
 static struct led_classdev msiacpi_led_kbdlight = {
@@ -3073,6 +3204,10 @@ static int __init msi_ec_init(void)
 	if (conf.leds.mute_led_address != MSI_EC_ADDR_UNSUPP)
 		led_classdev_register(&msi_platform_device->dev,
 				      &mute_led_cdev);
+	
+	if (conf.leds.stealth_led_address != MSI_EC_ADDR_UNSUPP)
+		led_classdev_register(&msi_platform_device->dev,
+				      &stealth_led_cdev);
 
 	if (conf.kbd_bl.bl_state_address != MSI_EC_ADDR_UNSUPP)
 		led_classdev_register(&msi_platform_device->dev,
@@ -3090,6 +3225,9 @@ static void __exit msi_ec_exit(void)
 
 		if (conf.leds.mute_led_address != MSI_EC_ADDR_UNSUPP)
 			led_classdev_unregister(&mute_led_cdev);
+
+		if (conf.leds.stealth_led_address != MSI_EC_ADDR_UNSUPP)
+			led_classdev_unregister(&stealth_led_cdev);
 
 		if (conf.kbd_bl.bl_state_address != MSI_EC_ADDR_UNSUPP)
 			led_classdev_unregister(&msiacpi_led_kbdlight);


### PR DESCRIPTION
Adds support for the leds on the rear of MSI stealth laptops for `14K1EMS1.108` (Stealth 14 Studio A13V)

**Changes:**
- add stealth_led_address and stealth_led_bit (as it uses a different bit than the existing keyboard leds)
- add logic for handling stealth led (exactly the same as mic and micmute leds)
- create `CONF_G2_11`, a direct copy of `CONF_G2_5`
- set `14K1EMS1.108` to use the new `CONF_G2_11`
- set `stealth_led_address = 0x2c` and `stealth_led_bit = 4` in `CONF_G2_11`

**Testing:**
- windows method used to find address and value for toggling the led
- Verified with RWEverything and msi-ec debug: writing 0x2c = 0x10 turns on the stealth LED; 0x2c = 0x12 turns on stealth+micmute; 0x2c = 0x00 turns both off.
- Built and loaded the kernel module with these changes; toggling `/sys/class/leds/platform::stealth/brightness` between 1 and 0 turns the rear light on and off without any other effects.

**Note:**
- setting `/sys/devices/platform/msi-ec/shift_mode` to `eco` turns off the stealth led regardless of the value set in `/sys/class/leds/platform::stealth/brightness`, this is the same behavior as using the official MSI Center app